### PR TITLE
improve graft init; add graft use for pinning sessions; connect --background for unselectable; and root conflict detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ graft sync                     # sync files to the remote
 graft forward go make          # forward commands to the remote
 ```
 
-All of these commands detect the connection from your current directory. You can also specify a connection explicitly with `--to <connection>`.
+All of these commands detect the connection from your current directory. You can also specify a connection explicitly with `--to <connection>`, or pin a connection to your shell session with `graft use <connection>`.
 
 ## Commands
 
@@ -98,9 +98,81 @@ All of these commands detect the connection from your current directory. You can
 | `shell`      | Open a remote shell                                                  |
 | `sync`       | Sync files to the remote                                             |
 | `forward`    | Forward local commands to the remote                                 |
+| `use`        | Pin a connection to the current shell session                        |
 | `status`     | Show connection status                                               |
 | `doctor`     | Check environment setup and diagnose issues                          |
 | `init`       | Generate a graft.yaml configuration file for future `graft connect`s |
+
+## Connection selection
+
+When you run a command like `graft run` or `graft shell`, graft needs to know which connection to use. It follows this hierarchy:
+
+1. **Explicit** - `--to <connection>` on the command line
+2. **Session pin** - set with `graft use <connection>`, applies to the current shell
+3. **CWD-based** - automatically detected from your working directory based on each connection's local root
+
+`graft use` is useful when you have multiple connections and want to lock your shell to a specific one:
+
+```bash
+graft use labos          # pin this shell to the "labos" connection
+graft shell              # opens a shell on labos, regardless of cwd
+graft use --clear        # resume CWD-based auto-selection
+```
+
+## Projects and workspaces
+
+Instead of passing flags to `graft connect` every time, you can save connection settings in a `graft.yaml` file.
+
+### Project config
+
+A project config lives in a project directory and defines how to connect:
+
+```bash
+graft init . ubuntu@myhost:~/mydir --name myconn --sync --forward make
+```
+
+This creates a `graft.yaml`:
+
+```yaml
+version: v1
+forward:
+  - make
+destinations:
+  myconn:
+    host: myhost
+    user: ubuntu
+    syncTo: ~/mydir
+    sync: true
+```
+
+Then `graft connect` with no arguments from that directory reads the config automatically.
+
+### Workspace config
+
+A workspace groups multiple projects under a shared root. Create one with:
+
+```bash
+cd ~/work
+graft init --workspace
+```
+
+This creates a `graft.yaml` with `workspace: true`. When you run `graft connect` from a project directory inside the workspace, graft walks up the directory tree looking for the workspace root. If found and `syncWorkspace` is enabled, the entire workspace directory is synced rather than just the project subdirectory.
+
+```
+~/work/                  <- workspace root (graft.yaml with workspace: true)
+  infra/
+    projectA/            <- project (graft.yaml with destinations)
+    projectB/            <- project (graft.yaml with destinations)
+```
+
+### Background connections
+
+Connections created with `--background` are excluded from CWD-based auto-selection. This is useful for auxiliary connections (e.g. a shared build server) that you only want to use explicitly via `--to` or `graft use`:
+
+```bash
+graft connect . user@build-server --background --name build
+graft use build          # explicitly switch to it
+```
 
 ## Coming Soon
 

--- a/cmd/graft/activate.go
+++ b/cmd/graft/activate.go
@@ -71,19 +71,10 @@ function _graft_preexec () {
 }
 
 function _graft_resolve_connection () {
-  local _gc_roots_file=$GRAFT_STATE_HOME/graft/local/connection_roots
+  local _gc_conn_file=$GRAFT_STATE_HOME/graft/local/sessions/$GRAFT_SESSION/current_connection
   GRAFT_CONNECTION=""
-  if [[ -f "$_gc_roots_file" ]]; then
-    local _gc_cwd
-    _gc_cwd=$(pwd -P 2>/dev/null || pwd)
-    local _gc_line
-    while IFS=$'\t' read -r _gc_root _gc_name; do
-      [[ -n "$_gc_root" ]] || continue
-      if [[ "${_gc_cwd:l}" = "${_gc_root:l}"* ]]; then
-        GRAFT_CONNECTION=$_gc_name
-        break
-      fi
-    done < "$_gc_roots_file"
+  if [[ -f "$_gc_conn_file" ]]; then
+    GRAFT_CONNECTION=$(<"$_gc_conn_file")
   fi
   export GRAFT_CONNECTION
 }
@@ -151,20 +142,10 @@ _graft_preexec () {
 }
 
 _graft_resolve_connection () {
-  local _gc_roots_file=$GRAFT_STATE_HOME/graft/local/connection_roots
+  local _gc_conn_file=$GRAFT_STATE_HOME/graft/local/sessions/$GRAFT_SESSION/current_connection
   GRAFT_CONNECTION=""
-  if [[ -f "$_gc_roots_file" ]]; then
-    local _gc_cwd
-    _gc_cwd=$(pwd -P 2>/dev/null || pwd)
-    _gc_cwd="${_gc_cwd,,}"
-    local _gc_root _gc_name
-    while IFS=$'\t' read -r _gc_root _gc_name; do
-      [[ -n "$_gc_root" ]] || continue
-      if [[ "$_gc_cwd" = "${_gc_root,,}"* ]]; then
-        GRAFT_CONNECTION=$_gc_name
-        break
-      fi
-    done < "$_gc_roots_file"
+  if [[ -f "$_gc_conn_file" ]]; then
+    GRAFT_CONNECTION=$(< "$_gc_conn_file")
   fi
   export GRAFT_CONNECTION
 }
@@ -228,20 +209,10 @@ function _graft_postcmd --on-event fish_postexec
 end
 
 function _graft_update_connection
-  set -l _gc_roots_file $_GC_STATE_HOME/graft/local/connection_roots
+  set -l _gc_conn_file $_GC_STATE_HOME/graft/local/sessions/$GRAFT_SESSION/current_connection
   set -gx GRAFT_CONNECTION ""
-  if test -f $_gc_roots_file
-    set -l _gc_cwd (pwd -P 2>/dev/null; or pwd)
-    set _gc_cwd (string lower $_gc_cwd)
-    while read -l _gc_line
-      set -l _gc_parts (string split \t $_gc_line)
-      test (count $_gc_parts) -ge 2; or continue
-      set -l _gc_root (string lower $_gc_parts[1])
-      if string match -q "$_gc_root*" $_gc_cwd
-        set -gx GRAFT_CONNECTION $_gc_parts[2]
-        return
-      end
-    end < $_gc_roots_file
+  if test -f $_gc_conn_file
+    set -gx GRAFT_CONNECTION (cat $_gc_conn_file)
   end
 end
 

--- a/cmd/graft/activate_test.go
+++ b/cmd/graft/activate_test.go
@@ -11,6 +11,8 @@ import (
 	"go.viam.com/test"
 )
 
+const shellZsh = "zsh"
+
 var testGraftBinary string
 
 func TestMain(m *testing.M) {
@@ -147,11 +149,11 @@ func TestActivateScriptConnectionPrompt(t *testing.T) {
 			script, err := generateActivateScript(shell, exePath)
 			test.That(t, err, test.ShouldBeNil)
 
-			// Script must NOT read per-session current_connection file (uses connection_roots only)
-			test.That(t, script, test.ShouldNotContainSubstring, "current_connection")
+			// Script reads per-session current_connection file (written by daemon, respects pins + CWD)
+			test.That(t, script, test.ShouldContainSubstring, "current_connection")
 
-			// Script uses global connection_roots file for immediate CWD matching
-			test.That(t, script, test.ShouldContainSubstring, "connection_roots")
+			// Script should NOT duplicate CWD matching - the daemon handles that
+			test.That(t, script, test.ShouldNotContainSubstring, "connection_roots")
 
 			// Script sets GRAFT_CONNECTION env var
 			test.That(t, script, test.ShouldContainSubstring, "GRAFT_CONNECTION")
@@ -160,6 +162,80 @@ func TestActivateScriptConnectionPrompt(t *testing.T) {
 			test.That(t, script, test.ShouldContainSubstring, "GRAFT_PROMPT_DISABLE")
 		})
 	}
+}
+
+func setupSessionConnFile(t *testing.T, connName string) string {
+	t.Helper()
+
+	tmpHome := t.TempDir()
+	stateDir := filepath.Join(tmpHome, ".local", "state", "graft", "local", "sessions", "12345")
+	test.That(t, os.MkdirAll(filepath.Join(stateDir, "shims"), 0o755), test.ShouldBeNil)
+	test.That(t, os.WriteFile(filepath.Join(stateDir, "current_connection"), []byte(connName), 0o600), test.ShouldBeNil)
+
+	return tmpHome
+}
+
+func TestActivatePromptReadsCurrentConnectionFile(t *testing.T) {
+	for _, shell := range []string{shellZsh, "bash"} {
+		t.Run(shell, func(t *testing.T) {
+			if !shellAvailable(shell) {
+				t.Skipf("%s not available on this system", shell)
+			}
+
+			tmpHome := setupSessionConnFile(t, "labos")
+
+			script := fmt.Sprintf(`
+eval "$(%s activate %s)"
+export GRAFT_SESSION=12345
+_graft_resolve_connection
+echo "CONNECTION=$GRAFT_CONNECTION"
+`, testGraftBinary, shell)
+
+			args := []string{"--norc", "--noprofile", "-c", script}
+			if shell == shellZsh {
+				args = []string{"-f", "-c", script}
+			}
+
+			cmd := exec.CommandContext(context.Background(), shell, args...)
+
+			cmd.Env = append(os.Environ(), "HOME="+tmpHome)
+
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Logf("%s test output:\n%s", shell, string(output))
+			}
+
+			test.That(t, err, test.ShouldBeNil)
+			test.That(t, string(output), test.ShouldContainSubstring, "CONNECTION=labos")
+		})
+	}
+
+	t.Run("fish", func(t *testing.T) {
+		if !shellAvailable("fish") {
+			t.Skip("fish not available on this system")
+		}
+
+		tmpHome := setupSessionConnFile(t, "labos")
+
+		script := fmt.Sprintf(`
+%s activate fish | source 2>/dev/null
+set -gx GRAFT_SESSION 12345
+_graft_update_connection
+echo "CONNECTION=$GRAFT_CONNECTION"
+`, testGraftBinary)
+
+		cmd := exec.CommandContext(context.Background(), "fish", "--no-config", "-c", script)
+
+		cmd.Env = append(os.Environ(), "HOME="+tmpHome)
+
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Logf("fish test output:\n%s", string(output))
+		}
+
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, string(output), test.ShouldContainSubstring, "CONNECTION=labos")
+	})
 }
 
 func TestActivateScriptConnectionPromptPrefix(t *testing.T) {

--- a/cmd/graft/connect.go
+++ b/cmd/graft/connect.go
@@ -19,6 +19,7 @@ var (
 	connectForwardPrefix bool
 	connectSyncFlag      bool
 	connectOS            string
+	connectBackground    bool
 )
 
 var connectCmd = &cobra.Command{
@@ -50,14 +51,7 @@ Use --sync with local_dir and remote_dir to enable file synchronization.`,
 		// Parse remote_dir from destination (SCP-style colon syntax).
 		// Only for non-docker destinations.
 		if !strings.HasPrefix(destination, "docker://") {
-			if strings.HasPrefix(destination, "ssh://") {
-				// For ssh:// URLs, extract remote dir from the path component
-				// so that ssh://user@host:22 (port) is not confused with
-				// user@host:~/dir (remote dir).
-				destination, remoteDir = parseSSHURLRemoteDir(destination)
-			} else {
-				destination, remoteDir = parseDestinationRemoteDir(destination)
-			}
+			destination, remoteDir = parseDestination(destination)
 		}
 
 		// Resolve local_dir to absolute path.
@@ -80,6 +74,7 @@ Use --sync with local_dir and remote_dir to enable file synchronization.`,
 			ForwardCommands: connectForward,
 			ForwardPrefix:   connectForwardPrefix,
 			WithSync:        connectSyncFlag,
+			Background:      connectBackground,
 		}
 
 		switch {
@@ -97,7 +92,7 @@ Use --sync with local_dir and remote_dir to enable file synchronization.`,
 				return cliExit("--os is only valid for docker:// destinations", 1)
 			}
 
-			params.Destination = strings.TrimPrefix(destination, "ssh://")
+			params.Destination = destination
 
 			return client.InitializeRemoteConnection(ctx, params)
 		}
@@ -141,6 +136,18 @@ func parseSSHURLRemoteDir(dest string) (string, string) {
 
 	// Not a port - the whole thing is a remote dir (e.g., "some:path").
 	return "ssh://" + bareDest, afterHost
+}
+
+// parseDestination parses a raw destination string into a bare host (user@host, no scheme)
+// and an optional remote directory. It handles both ssh:// URLs and SCP-style user@host:dir.
+func parseDestination(raw string) (string, string) {
+	if strings.HasPrefix(raw, "ssh://") {
+		dest, dir := parseSSHURLRemoteDir(raw)
+
+		return strings.TrimPrefix(dest, "ssh://"), dir
+	}
+
+	return parseDestinationRemoteDir(raw)
 }
 
 func isNumeric(s string) bool {
@@ -298,6 +305,9 @@ func resolveProjectConnectParams(in resolveProjectConnectInput) graft.ConnectPar
 		ForwardPrefix:   in.destConfig.Prefix,
 	}
 
+	// Workspace sync takes precedence over project-level sync because it syncs
+	// the entire workspace directory (setting SyncSource/SyncDest), making a
+	// narrower project sync redundant.
 	if in.syncWorkspace && in.workspaceDir != "" {
 		relPath, err := filepath.Rel(in.workspaceDir, in.projectDir)
 		if err == nil && relPath != "." {
@@ -306,6 +316,8 @@ func resolveProjectConnectParams(in resolveProjectConnectInput) graft.ConnectPar
 
 		params.SyncSource = in.workspaceDir
 		params.SyncDest = in.destConfig.SyncTo
+		params.WithSync = true
+	} else if in.destConfig.Sync {
 		params.WithSync = true
 	}
 
@@ -330,6 +342,7 @@ func init() {
 	connectCmd.Flags().BoolVar(&connectForwardPrefix, "forward-prefix", false, "Forward with connection name prefix")
 	connectCmd.Flags().BoolVar(&connectSyncFlag, "sync", false, "Enable file synchronization")
 	connectCmd.Flags().StringVar(&connectOS, "os", "", "Container OS (docker:// only)")
+	connectCmd.Flags().BoolVar(&connectBackground, "background", false, "Exclude from CWD-based auto-selection")
 
 	rootCmd.AddCommand(connectCmd)
 	rootCmd.AddCommand(disconnectCmd)

--- a/cmd/graft/connect_test.go
+++ b/cmd/graft/connect_test.go
@@ -117,6 +117,41 @@ func TestResolveProjectConnectParams(t *testing.T) {
 		test.That(t, params.SyncDest, test.ShouldBeEmpty)
 		test.That(t, params.WithSync, test.ShouldBeFalse)
 	})
+
+	t.Run("project-level sync without workspace", func(t *testing.T) {
+		params := resolveProjectConnectParams(resolveProjectConnectInput{
+			projectDir:    "/home/user/myproject",
+			destName:      "myconn",
+			destConfig:    ProjectDestinationConfig{Host: "myhost", User: "ubuntu", SyncTo: "~/proj", Sync: true},
+			forwards:      []string{"make"},
+			workspaceDir:  "",
+			syncWorkspace: false,
+		})
+
+		test.That(t, params.WithSync, test.ShouldBeTrue)
+		test.That(t, params.RemoteRoot, test.ShouldEqual, "~/proj")
+	})
+
+	t.Run("project sync false means no sync without workspace", func(t *testing.T) {
+		params := resolveProjectConnectParams(resolveProjectConnectInput{
+			projectDir:    "/home/user/myproject",
+			destName:      "myconn",
+			destConfig:    ProjectDestinationConfig{Host: "myhost", User: "ubuntu", SyncTo: "~/proj", Sync: false},
+			forwards:      []string{"make"},
+			workspaceDir:  "",
+			syncWorkspace: false,
+		})
+
+		test.That(t, params.WithSync, test.ShouldBeFalse)
+	})
+}
+
+func TestConnectBackgroundFlag(t *testing.T) {
+	t.Run("flag is registered and defaults to false", func(t *testing.T) {
+		flag := connectCmd.Flags().Lookup("background")
+		test.That(t, flag, test.ShouldNotBeNil)
+		test.That(t, flag.DefValue, test.ShouldEqual, "false")
+	})
 }
 
 func TestParseConnectArgs(t *testing.T) {

--- a/cmd/graft/helpers.go
+++ b/cmd/graft/helpers.go
@@ -76,6 +76,7 @@ type ProjectDestinationConfig struct {
 	User   string `yaml:"user"`
 	SyncTo string `yaml:"syncTo"`
 	Prefix bool   `yaml:"prefix"`
+	Sync   bool   `yaml:"sync"`
 }
 
 type ProjectConfig struct {

--- a/cmd/graft/init.go
+++ b/cmd/graft/init.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -12,15 +13,16 @@ import (
 )
 
 var (
-	initWorkspace bool
-	initSyncTo    string
-	initForward   []string
-	initPrefix    bool
-	initForce     bool
+	initWorkspace     bool
+	initName          string
+	initSync          bool
+	initForward       []string
+	initForwardPrefix bool
+	initForce         bool
 )
 
 var initCmd = &cobra.Command{
-	Use:   "init [flags] [name] [destination]",
+	Use:   "init [flags] <local_dir> <destination>[:<remote_dir>]",
 	Short: "Generate a graft.yaml configuration file",
 	Long: `Generate a graft.yaml configuration file.
 
@@ -28,7 +30,10 @@ Workspace mode (--workspace, 0 args):
   graft init --workspace
 
 Project mode (2 args):
-  graft init <name> <destination> [flags]`,
+  graft init <local_dir> <destination>[:<remote_dir>] --name <name> [flags]
+
+Example:
+  graft init . ubuntu@myhost:~/mydir --sync --name myconn --forward make`,
 	RunE: func(_ *cobra.Command, args []string) error {
 		if initWorkspace {
 			if len(args) != 0 {
@@ -39,7 +44,11 @@ Project mode (2 args):
 		}
 
 		if len(args) != 2 {
-			return cliExit("expected 2 arguments: name and destination", 1)
+			return cliExit("expected 2 arguments: local_dir and destination", 1)
+		}
+
+		if initName == "" {
+			return cliExit("--name is required", 1)
 		}
 
 		return runInitProject(args[0], args[1])
@@ -47,7 +56,7 @@ Project mode (2 args):
 }
 
 func runInitWorkspace() error {
-	if err := checkExistingConfig(); err != nil {
+	if err := checkExistingConfig("."); err != nil {
 		return err
 	}
 
@@ -69,32 +78,49 @@ func runInitWorkspace() error {
 	return nil
 }
 
-func runInitProject(name, destination string) error {
-	if err := checkExistingConfig(); err != nil {
-		return err
+func runInitProject(localDir, rawDestination string) error {
+	absDir, err := filepath.Abs(localDir)
+	if err != nil {
+		return errors.Wrap(err)
 	}
 
-	cfg := buildProjectConfig(name, destination, initSyncTo, initForward, initPrefix)
+	if checkErr := checkExistingConfig(absDir); checkErr != nil {
+		return checkErr
+	}
+
+	destination, remoteDir := parseDestination(rawDestination)
+
+	var user, host string
+	if i := strings.LastIndex(destination, "@"); i != -1 {
+		user = destination[:i]
+		host = destination[i+1:]
+	} else {
+		host = destination
+	}
+
+	cfg := buildProjectConfig(initName, host, user, remoteDir, initForward, initForwardPrefix, initSync)
 
 	data, err := yaml.Marshal(cfg)
 	if err != nil {
 		return errors.Wrap(err)
 	}
 
-	if err := os.WriteFile("graft.yaml", data, 0o600); err != nil {
+	configPath := filepath.Join(absDir, "graft.yaml")
+
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
 		return errors.Wrap(err)
 	}
 
 	fmt.Fprintln(os.Stderr, "created graft.yaml")
 
-	dest := cfg.Destinations[name]
+	dest := cfg.Destinations[initName]
 
 	displayHost := dest.Host
 	if dest.User != "" {
 		displayHost = dest.User + "@" + dest.Host
 	}
 
-	fmt.Fprintf(os.Stderr, "  destination: %s -> %s\n", name, displayHost)
+	fmt.Fprintf(os.Stderr, "  destination: %s -> %s\n", initName, displayHost)
 
 	if dest.SyncTo != "" {
 		fmt.Fprintf(os.Stderr, "  sync to:     %s\n", dest.SyncTo)
@@ -105,7 +131,7 @@ func runInitProject(name, destination string) error {
 		if dest.Prefix {
 			prefixed := make([]string, len(displayForwards))
 			for i, f := range displayForwards {
-				prefixed[i] = name + "-" + f
+				prefixed[i] = initName + "-" + f
 			}
 
 			displayForwards = prefixed
@@ -120,12 +146,12 @@ func runInitProject(name, destination string) error {
 	return nil
 }
 
-func checkExistingConfig() error {
+func checkExistingConfig(dir string) error {
 	if initForce {
 		return nil
 	}
 
-	if _, err := os.Stat("graft.yaml"); err == nil {
+	if _, err := os.Stat(filepath.Join(dir, "graft.yaml")); err == nil {
 		return cliExit("graft.yaml already exists (use --force to overwrite)", 1)
 	}
 
@@ -140,20 +166,13 @@ func buildWorkspaceConfig() WorkspaceConfig {
 	}
 }
 
-func buildProjectConfig(name, destination, syncTo string, forwards []string, prefix bool) ProjectConfig {
-	var user, host string
-	if i := strings.LastIndex(destination, "@"); i != -1 {
-		user = destination[:i]
-		host = destination[i+1:]
-	} else {
-		host = destination
-	}
-
+func buildProjectConfig(name, host, user, remoteDir string, forwards []string, prefix, sync bool) ProjectConfig {
 	destConfig := ProjectDestinationConfig{
 		Host:   host,
 		User:   user,
-		SyncTo: syncTo,
+		SyncTo: remoteDir,
 		Prefix: prefix,
+		Sync:   sync,
 	}
 
 	return ProjectConfig{
@@ -165,9 +184,10 @@ func buildProjectConfig(name, destination, syncTo string, forwards []string, pre
 
 func init() {
 	initCmd.Flags().BoolVar(&initWorkspace, "workspace", false, "Generate workspace config instead of project config")
-	initCmd.Flags().StringVar(&initSyncTo, "sync-to", "", "Remote sync destination path")
+	initCmd.Flags().StringVarP(&initName, "name", "n", "", "Connection name (required for project mode)")
+	initCmd.Flags().BoolVar(&initSync, "sync", false, "Enable file synchronization")
 	initCmd.Flags().StringSliceVar(&initForward, "forward", nil, "Commands to forward")
-	initCmd.Flags().BoolVar(&initPrefix, "prefix", false, "Prefix forwarded commands with connection name")
+	initCmd.Flags().BoolVar(&initForwardPrefix, "forward-prefix", false, "Prefix forwarded commands with connection name")
 	initCmd.Flags().BoolVar(&initForce, "force", false, "Overwrite existing graft.yaml")
 
 	rootCmd.AddCommand(initCmd)

--- a/cmd/graft/init_test.go
+++ b/cmd/graft/init_test.go
@@ -29,7 +29,7 @@ func TestBuildWorkspaceConfig(t *testing.T) {
 
 func TestBuildProjectConfig(t *testing.T) {
 	t.Run("basic with user@host", func(t *testing.T) {
-		cfg := buildProjectConfig("anvil", "ubuntu@anvil-host", "", nil, false)
+		cfg := buildProjectConfig("anvil", "anvil-host", "ubuntu", "", nil, false, false)
 
 		test.That(t, cfg.Version, test.ShouldEqual, "v1")
 		test.That(t, cfg.Forwards, test.ShouldBeEmpty)
@@ -40,40 +40,49 @@ func TestBuildProjectConfig(t *testing.T) {
 		test.That(t, dest.User, test.ShouldEqual, "ubuntu")
 		test.That(t, dest.SyncTo, test.ShouldBeEmpty)
 		test.That(t, dest.Prefix, test.ShouldBeFalse)
+		test.That(t, dest.Sync, test.ShouldBeFalse)
 	})
 
 	t.Run("basic without user", func(t *testing.T) {
-		cfg := buildProjectConfig("myconn", "myhost", "", nil, false)
+		cfg := buildProjectConfig("myconn", "myhost", "", "", nil, false, false)
 
-		dest := cfg.Destinations["myconn"]
+		dest := cfg.Destinations[testConnName]
 		test.That(t, dest.Host, test.ShouldEqual, "myhost")
 		test.That(t, dest.User, test.ShouldBeEmpty)
 	})
 
-	t.Run("with sync-to", func(t *testing.T) {
-		cfg := buildProjectConfig("anvil", "ubuntu@anvil-host", "~/arc", nil, false)
+	t.Run("with remote dir as syncTo", func(t *testing.T) {
+		cfg := buildProjectConfig("anvil", "anvil-host", "ubuntu", "~/arc", nil, false, false)
 
 		dest := cfg.Destinations["anvil"]
 		test.That(t, dest.SyncTo, test.ShouldEqual, "~/arc")
 	})
 
 	t.Run("with forwards", func(t *testing.T) {
-		cfg := buildProjectConfig("anvil", "ubuntu@anvil-host", "", []string{"pulumi", "kubectl", "k9s"}, false)
+		cfg := buildProjectConfig("anvil", "anvil-host", "ubuntu", "", []string{"pulumi", "kubectl", "k9s"}, false, false)
 
 		test.That(t, cfg.Forwards, test.ShouldResemble, []string{"pulumi", "kubectl", "k9s"})
 		test.That(t, cfg.Destinations["anvil"].Prefix, test.ShouldBeFalse)
 	})
 
 	t.Run("with forwards and prefix", func(t *testing.T) {
-		cfg := buildProjectConfig("anvil", "ubuntu@anvil-host", "~/arc", []string{"pulumi", "kubectl", "k9s"}, true)
+		cfg := buildProjectConfig("anvil", "anvil-host", "ubuntu", "~/arc", []string{"pulumi", "kubectl", "k9s"}, true, false)
 
 		test.That(t, cfg.Forwards, test.ShouldResemble, []string{"pulumi", "kubectl", "k9s"})
 		test.That(t, cfg.Destinations["anvil"].Prefix, test.ShouldBeTrue)
 		test.That(t, cfg.Destinations["anvil"].SyncTo, test.ShouldEqual, "~/arc")
 	})
 
+	t.Run("with sync enabled", func(t *testing.T) {
+		cfg := buildProjectConfig("anvil", "anvil-host", "ubuntu", "~/arc", nil, false, true)
+
+		dest := cfg.Destinations["anvil"]
+		test.That(t, dest.SyncTo, test.ShouldEqual, "~/arc")
+		test.That(t, dest.Sync, test.ShouldBeTrue)
+	})
+
 	t.Run("round-trip with connectFromProject structs", func(t *testing.T) {
-		cfg := buildProjectConfig("myconn", "user@host", "~/proj", []string{"make", "go"}, true)
+		cfg := buildProjectConfig("myconn", "host", "user", "~/proj", []string{"make", "go"}, true, true)
 
 		data, err := yaml.Marshal(cfg)
 		test.That(t, err, test.ShouldBeNil)
@@ -92,6 +101,112 @@ func TestBuildProjectConfig(t *testing.T) {
 		test.That(t, dest.User, test.ShouldEqual, "user")
 		test.That(t, dest.SyncTo, test.ShouldEqual, "~/proj")
 		test.That(t, dest.Prefix, test.ShouldBeTrue)
+		test.That(t, dest.Sync, test.ShouldBeTrue)
+	})
+}
+
+const testConnName = "myconn"
+
+func resetInitFlags() {
+	initName = testConnName
+	initSync = false
+	initForward = nil
+	initForwardPrefix = false
+	initForce = false
+}
+
+func TestRunInitProject(t *testing.T) {
+	t.Run("writes config to specified local dir", func(t *testing.T) {
+		dir := t.TempDir()
+
+		resetInitFlags()
+
+		err := runInitProject(dir, "ubuntu@myhost:~/proj")
+		test.That(t, err, test.ShouldBeNil)
+
+		data, err := os.ReadFile(filepath.Join(dir, "graft.yaml"))
+		test.That(t, err, test.ShouldBeNil)
+
+		var cfg ProjectConfig
+
+		err = yaml.Unmarshal(data, &cfg)
+		test.That(t, err, test.ShouldBeNil)
+
+		test.That(t, cfg.Destinations, test.ShouldHaveLength, 1)
+		dest := cfg.Destinations[testConnName]
+		test.That(t, dest.Host, test.ShouldEqual, "myhost")
+		test.That(t, dest.User, test.ShouldEqual, "ubuntu")
+		test.That(t, dest.SyncTo, test.ShouldEqual, "~/proj")
+		test.That(t, dest.Sync, test.ShouldBeFalse)
+	})
+
+	t.Run("parses ssh:// URL remote dir", func(t *testing.T) {
+		dir := t.TempDir()
+
+		resetInitFlags()
+
+		err := runInitProject(dir, "ssh://ubuntu@myhost:~/proj")
+		test.That(t, err, test.ShouldBeNil)
+
+		data, err := os.ReadFile(filepath.Join(dir, "graft.yaml"))
+		test.That(t, err, test.ShouldBeNil)
+
+		var cfg ProjectConfig
+
+		err = yaml.Unmarshal(data, &cfg)
+		test.That(t, err, test.ShouldBeNil)
+
+		dest := cfg.Destinations[testConnName]
+		test.That(t, dest.Host, test.ShouldEqual, "myhost")
+		test.That(t, dest.User, test.ShouldEqual, "ubuntu")
+		test.That(t, dest.SyncTo, test.ShouldEqual, "~/proj")
+	})
+
+	t.Run("with sync flag", func(t *testing.T) {
+		dir := t.TempDir()
+
+		resetInitFlags()
+
+		initSync = true
+
+		err := runInitProject(dir, "ubuntu@myhost:~/proj")
+		test.That(t, err, test.ShouldBeNil)
+
+		data, err := os.ReadFile(filepath.Join(dir, "graft.yaml"))
+		test.That(t, err, test.ShouldBeNil)
+
+		var cfg ProjectConfig
+
+		err = yaml.Unmarshal(data, &cfg)
+		test.That(t, err, test.ShouldBeNil)
+
+		dest := cfg.Destinations[testConnName]
+		test.That(t, dest.Sync, test.ShouldBeTrue)
+	})
+
+	t.Run("refuses overwrite without force", func(t *testing.T) {
+		dir := t.TempDir()
+		err := os.WriteFile(filepath.Join(dir, "graft.yaml"), []byte("existing"), 0o600)
+		test.That(t, err, test.ShouldBeNil)
+
+		resetInitFlags()
+
+		err = runInitProject(dir, "ubuntu@myhost")
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "already exists")
+	})
+
+	t.Run("force overwrites existing config", func(t *testing.T) {
+		dir := t.TempDir()
+		err := os.WriteFile(filepath.Join(dir, "graft.yaml"), []byte("existing"), 0o600)
+		test.That(t, err, test.ShouldBeNil)
+
+		resetInitFlags()
+
+		initForce = true
+
+		err = runInitProject(dir, "ubuntu@myhost")
+		test.That(t, err, test.ShouldBeNil)
 	})
 }
 

--- a/cmd/graft/use.go
+++ b/cmd/graft/use.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var useClear bool
+
+var useCmd = &cobra.Command{
+	Use:   "use [connection-name]",
+	Short: "Pin a connection to the current session",
+	Long: `Pin a connection to the current shell session, overriding CWD-based auto-selection.
+
+Use --clear to remove the pin and resume CWD-based selection.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 && !useClear {
+			return cliExit("connection name required (or use --clear to unpin)", 1)
+		}
+
+		client, ctx := newClient(cmd.Context(), true)
+		defer client.Close()
+
+		var connName string
+		if len(args) == 1 && !useClear {
+			connName = args[0]
+		}
+
+		if err := client.PinConnection(ctx, connName); err != nil {
+			return cliExit(err, 1)
+		}
+
+		if connName != "" {
+			fmt.Fprintf(os.Stderr, "pinned session to %s\n", connName)
+		} else {
+			fmt.Fprintln(os.Stderr, "cleared session pin")
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	useCmd.Flags().BoolVar(&useClear, "clear", false, "Clear the session pin")
+
+	rootCmd.AddCommand(useCmd)
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,12 +168,24 @@ A session represents an active shell where graft is activated. It is identified 
 3. Prepends the shim directory to `PATH`
 4. Saves the original PATH as `_GC_LOCAL_PATH`
 5. Installs shell hooks:
-  - **precmd/prompt** - reports the current working directory to the daemon and resolves which connection is active for the prompt
+  - **precmd/prompt** - reports the current working directory to the daemon and reads the session's `current_connection` file to set `GRAFT_CONNECTION` for the prompt
   - **preexec** - extracts inline environment variable assignments for security
+
+### Connection selection
+
+When a session needs a connection (for running commands, opening a shell, etc.), the daemon follows this hierarchy:
+
+1. **Explicit name** - `--to <connection>` on the command line
+2. **Session pin** - set via `graft use <connection>`, stored as `pinnedConnection` on the session
+3. **CWD-based** - matches the session's current working directory against each connection's `localRoot`
+
+Background connections (created with `--background`) are excluded from CWD-based matching but can still be used explicitly or via pinning.
+
+If multiple non-background connections match the CWD, auto-selection is refused and the user must pin or specify explicitly.
 
 ### CWD tracking
 
-Every time the prompt renders, the shell hook runs `graft report-cwd` in the background. The daemon uses this to determine which connection matches the current directory (by comparing against each connection's `localRoot`). This drives both the shell prompt indicator (`[connection-name]`) and which commands get shimmed.
+Every time the prompt renders, the shell hook runs `graft report-cwd` in the background. The daemon uses this to update the session's CWD state. The reconciliation loop then writes the resolved connection name to the session's `current_connection` file, which the shell prompt reads to display `[connection-name]`. The resolved name respects the selection hierarchy above (pin takes precedence over CWD).
 
 ## Command shimming
 
@@ -276,8 +288,8 @@ If a local port is already in use, the forward is marked as a conflict and repor
 | `~/.config/graft/local/config.yml` | Connection configuration |
 | `~/.local/state/graft/local/graftd.sock` | Local daemon socket |
 | `~/.local/state/graft/local/graftd.pid` | Local daemon PID file |
-| `~/.local/state/graft/local/sessions/` | Per-session shim directories |
-| `~/.local/state/graft/local/connection_roots` | CWD-to-connection mapping for shell prompt |
+| `~/.local/state/graft/local/sessions/` | Per-session shim directories and `current_connection` files |
+| `~/.local/state/graft/local/connection_roots` | CWD-to-connection mapping (used internally by the daemon) |
 | `~/.local/state/graft/local/logs/` | Local daemon logs |
 | `~/.cache/graft/binaries/` | Cached cross-compiled remote daemon binaries |
 

--- a/gen/proto/graft/v1/graft.pb.go
+++ b/gen/proto/graft/v1/graft.pb.go
@@ -1083,6 +1083,7 @@ type InitializeSSHConnectionRequest struct {
 	Pid           uint64                 `protobuf:"varint,5,opt,name=pid,proto3" json:"pid,omitempty"`
 	LocalRoot     string                 `protobuf:"bytes,6,opt,name=local_root,json=localRoot,proto3" json:"local_root,omitempty"`
 	RemoteRoot    string                 `protobuf:"bytes,7,opt,name=remote_root,json=remoteRoot,proto3" json:"remote_root,omitempty"`
+	Background    bool                   `protobuf:"varint,8,opt,name=background,proto3" json:"background,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1166,6 +1167,13 @@ func (x *InitializeSSHConnectionRequest) GetRemoteRoot() string {
 	return ""
 }
 
+func (x *InitializeSSHConnectionRequest) GetBackground() bool {
+	if x != nil {
+		return x.Background
+	}
+	return false
+}
+
 type InitializeSSHConnectionResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -1219,6 +1227,7 @@ type InitializeContainerConnectionRequest struct {
 	UserName        string                 `protobuf:"bytes,5,opt,name=user_name,json=userName,proto3" json:"user_name,omitempty"`
 	LocalRoot       string                 `protobuf:"bytes,6,opt,name=local_root,json=localRoot,proto3" json:"local_root,omitempty"`
 	RemoteRoot      string                 `protobuf:"bytes,7,opt,name=remote_root,json=remoteRoot,proto3" json:"remote_root,omitempty"`
+	Background      bool                   `protobuf:"varint,8,opt,name=background,proto3" json:"background,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -1300,6 +1309,13 @@ func (x *InitializeContainerConnectionRequest) GetRemoteRoot() string {
 		return x.RemoteRoot
 	}
 	return ""
+}
+
+func (x *InitializeContainerConnectionRequest) GetBackground() bool {
+	if x != nil {
+		return x.Background
+	}
+	return false
 }
 
 type InitializeContainerConnectionResponse struct {
@@ -3564,6 +3580,102 @@ func (x *ForwardPortResponse) GetPayload() []byte {
 	return nil
 }
 
+type SessionPinConnectionRequest struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Pid            uint64                 `protobuf:"varint,1,opt,name=pid,proto3" json:"pid,omitempty"`
+	ConnectionName string                 `protobuf:"bytes,2,opt,name=connection_name,json=connectionName,proto3" json:"connection_name,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *SessionPinConnectionRequest) Reset() {
+	*x = SessionPinConnectionRequest{}
+	mi := &file_graft_v1_graft_proto_msgTypes[63]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SessionPinConnectionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SessionPinConnectionRequest) ProtoMessage() {}
+
+func (x *SessionPinConnectionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_graft_v1_graft_proto_msgTypes[63]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SessionPinConnectionRequest.ProtoReflect.Descriptor instead.
+func (*SessionPinConnectionRequest) Descriptor() ([]byte, []int) {
+	return file_graft_v1_graft_proto_rawDescGZIP(), []int{63}
+}
+
+func (x *SessionPinConnectionRequest) GetPid() uint64 {
+	if x != nil {
+		return x.Pid
+	}
+	return 0
+}
+
+func (x *SessionPinConnectionRequest) GetConnectionName() string {
+	if x != nil {
+		return x.ConnectionName
+	}
+	return ""
+}
+
+type SessionPinConnectionResponse struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	ConnectionName string                 `protobuf:"bytes,1,opt,name=connection_name,json=connectionName,proto3" json:"connection_name,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *SessionPinConnectionResponse) Reset() {
+	*x = SessionPinConnectionResponse{}
+	mi := &file_graft_v1_graft_proto_msgTypes[64]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SessionPinConnectionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SessionPinConnectionResponse) ProtoMessage() {}
+
+func (x *SessionPinConnectionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_graft_v1_graft_proto_msgTypes[64]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SessionPinConnectionResponse.ProtoReflect.Descriptor instead.
+func (*SessionPinConnectionResponse) Descriptor() ([]byte, []int) {
+	return file_graft_v1_graft_proto_rawDescGZIP(), []int{64}
+}
+
+func (x *SessionPinConnectionResponse) GetConnectionName() string {
+	if x != nil {
+		return x.ConnectionName
+	}
+	return ""
+}
+
 // PortForwardStatus is the status of a single port forward, shown in `graft status`.
 type PortForwardStatus struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
@@ -3578,7 +3690,7 @@ type PortForwardStatus struct {
 
 func (x *PortForwardStatus) Reset() {
 	*x = PortForwardStatus{}
-	mi := &file_graft_v1_graft_proto_msgTypes[63]
+	mi := &file_graft_v1_graft_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3590,7 +3702,7 @@ func (x *PortForwardStatus) String() string {
 func (*PortForwardStatus) ProtoMessage() {}
 
 func (x *PortForwardStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_graft_v1_graft_proto_msgTypes[63]
+	mi := &file_graft_v1_graft_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3603,7 +3715,7 @@ func (x *PortForwardStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PortForwardStatus.ProtoReflect.Descriptor instead.
 func (*PortForwardStatus) Descriptor() ([]byte, []int) {
-	return file_graft_v1_graft_proto_rawDescGZIP(), []int{63}
+	return file_graft_v1_graft_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *PortForwardStatus) GetRemotePort() uint32 {
@@ -3720,7 +3832,7 @@ const file_graft_v1_graft_proto_rawDesc = "" +
 	"\vconnections\x18\x01 \x03(\v22.graft.v1.ListConnectionsResponse.ConnectionsEntryR\vconnections\x1aZ\n" +
 	"\x10ConnectionsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
-	"\x05value\x18\x02 \x01(\v2\x1a.graft.v1.ConnectionStatusR\x05value:\x028\x01\"\xd7\x01\n" +
+	"\x05value\x18\x02 \x01(\v2\x1a.graft.v1.ConnectionStatusR\x05value:\x028\x01\"\xf7\x01\n" +
 	"\x1eInitializeSSHConnectionRequest\x12\x10\n" +
 	"\x03cwd\x18\x01 \x01(\tR\x03cwd\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
@@ -3730,9 +3842,12 @@ const file_graft_v1_graft_proto_rawDesc = "" +
 	"\n" +
 	"local_root\x18\x06 \x01(\tR\tlocalRoot\x12\x1f\n" +
 	"\vremote_root\x18\a \x01(\tR\n" +
-	"remoteRoot\"5\n" +
+	"remoteRoot\x12\x1e\n" +
+	"\n" +
+	"background\x18\b \x01(\bR\n" +
+	"background\"5\n" +
 	"\x1fInitializeSSHConnectionResponse\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\"\xf1\x01\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\"\x91\x02\n" +
 	"$InitializeContainerConnectionRequest\x12\x10\n" +
 	"\x03cwd\x18\x01 \x01(\tR\x03cwd\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1b\n" +
@@ -3742,7 +3857,10 @@ const file_graft_v1_graft_proto_rawDesc = "" +
 	"\n" +
 	"local_root\x18\x06 \x01(\tR\tlocalRoot\x12\x1f\n" +
 	"\vremote_root\x18\a \x01(\tR\n" +
-	"remoteRoot\";\n" +
+	"remoteRoot\x12\x1e\n" +
+	"\n" +
+	"background\x18\b \x01(\bR\n" +
+	"background\";\n" +
 	"%InitializeContainerConnectionResponse\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"-\n" +
 	"\x17RemoveConnectionRequest\x12\x12\n" +
@@ -3874,7 +3992,12 @@ const file_graft_v1_graft_proto_rawDesc = "" +
 	"\x04host\x18\x02 \x01(\tR\x04host\x12\x1a\n" +
 	"\bprotocol\x18\x03 \x01(\tR\bprotocol\"/\n" +
 	"\x13ForwardPortResponse\x12\x18\n" +
-	"\apayload\x18\x01 \x01(\fR\apayload\"\xb4\x01\n" +
+	"\apayload\x18\x01 \x01(\fR\apayload\"X\n" +
+	"\x1bSessionPinConnectionRequest\x12\x10\n" +
+	"\x03pid\x18\x01 \x01(\x04R\x03pid\x12'\n" +
+	"\x0fconnection_name\x18\x02 \x01(\tR\x0econnectionName\"G\n" +
+	"\x1cSessionPinConnectionResponse\x12'\n" +
+	"\x0fconnection_name\x18\x01 \x01(\tR\x0econnectionName\"\xb4\x01\n" +
 	"\x11PortForwardStatus\x12\x1f\n" +
 	"\vremote_port\x18\x01 \x01(\rR\n" +
 	"remotePort\x12\x1d\n" +
@@ -3889,7 +4012,7 @@ const file_graft_v1_graft_proto_rawDesc = "" +
 	"\x1aCONNECTION_STATE_CONNECTED\x10\x02\x12\x1b\n" +
 	"\x17CONNECTION_STATE_FAILED\x10\x03\x12\x1b\n" +
 	"\x17CONNECTION_STATE_CLOSED\x10\x04\x12!\n" +
-	"\x1dCONNECTION_STATE_RECONNECTING\x10\x052\x81\x12\n" +
+	"\x1dCONNECTION_STATE_RECONNECTING\x10\x052\xea\x12\n" +
 	"\fGraftService\x12=\n" +
 	"\x06Status\x12\x17.graft.v1.StatusRequest\x1a\x18.graft.v1.StatusResponse\"\x00\x127\n" +
 	"\x04Ping\x12\x15.graft.v1.PingRequest\x1a\x16.graft.v1.PingResponse\"\x00\x12C\n" +
@@ -3914,7 +4037,8 @@ const file_graft_v1_graft_proto_rawDesc = "" +
 	"\x10SessionReportCWD\x12!.graft.v1.SessionReportCWDRequest\x1a\".graft.v1.SessionReportCWDResponse\"\x00\x12O\n" +
 	"\fSessionWhich\x12\x1d.graft.v1.SessionWhichRequest\x1a\x1e.graft.v1.SessionWhichResponse\"\x00\x12m\n" +
 	"\x16SessionShimmedCommands\x12'.graft.v1.SessionShimmedCommandsRequest\x1a(.graft.v1.SessionShimmedCommandsResponse\"\x00\x12p\n" +
-	"\x17SessionSelectConnection\x12(.graft.v1.SessionSelectConnectionRequest\x1a).graft.v1.SessionSelectConnectionResponse\"\x00\x12M\n" +
+	"\x17SessionSelectConnection\x12(.graft.v1.SessionSelectConnectionRequest\x1a).graft.v1.SessionSelectConnectionResponse\"\x00\x12g\n" +
+	"\x14SessionPinConnection\x12%.graft.v1.SessionPinConnectionRequest\x1a&.graft.v1.SessionPinConnectionResponse\"\x00\x12M\n" +
 	"\n" +
 	"RunCommand\x12\x1b.graft.v1.RunCommandRequest\x1a\x1c.graft.v1.RunCommandResponse\"\x00(\x010\x01B\x88\x01\n" +
 	"\fcom.graft.v1B\n" +
@@ -3933,7 +4057,7 @@ func file_graft_v1_graft_proto_rawDescGZIP() []byte {
 }
 
 var file_graft_v1_graft_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_graft_v1_graft_proto_msgTypes = make([]protoimpl.MessageInfo, 66)
+var file_graft_v1_graft_proto_msgTypes = make([]protoimpl.MessageInfo, 68)
 var file_graft_v1_graft_proto_goTypes = []any{
 	(ConnectionState)(0),                            // 0: graft.v1.ConnectionState
 	(*VersionInfo)(nil),                             // 1: graft.v1.VersionInfo
@@ -3999,24 +4123,26 @@ var file_graft_v1_graft_proto_goTypes = []any{
 	(*ForwardPortRequest)(nil),                      // 61: graft.v1.ForwardPortRequest
 	(*ForwardPortStart)(nil),                        // 62: graft.v1.ForwardPortStart
 	(*ForwardPortResponse)(nil),                     // 63: graft.v1.ForwardPortResponse
-	(*PortForwardStatus)(nil),                       // 64: graft.v1.PortForwardStatus
-	nil,                                             // 65: graft.v1.ListConnectionsResponse.ConnectionsEntry
-	nil,                                             // 66: graft.v1.SessionShimmedCommandsResponse.DestinationCommandsEntry
-	(*durationpb.Duration)(nil),                     // 67: google.protobuf.Duration
+	(*SessionPinConnectionRequest)(nil),             // 64: graft.v1.SessionPinConnectionRequest
+	(*SessionPinConnectionResponse)(nil),            // 65: graft.v1.SessionPinConnectionResponse
+	(*PortForwardStatus)(nil),                       // 66: graft.v1.PortForwardStatus
+	nil,                                             // 67: graft.v1.ListConnectionsResponse.ConnectionsEntry
+	nil,                                             // 68: graft.v1.SessionShimmedCommandsResponse.DestinationCommandsEntry
+	(*durationpb.Duration)(nil),                     // 69: google.protobuf.Duration
 }
 var file_graft_v1_graft_proto_depIdxs = []int32{
 	1,  // 0: graft.v1.StatusResponse.version_info:type_name -> graft.v1.VersionInfo
-	67, // 1: graft.v1.StatusResponse.uptime:type_name -> google.protobuf.Duration
+	69, // 1: graft.v1.StatusResponse.uptime:type_name -> google.protobuf.Duration
 	13, // 2: graft.v1.SyncStatus.conflicts:type_name -> graft.v1.SyncConflict
 	14, // 3: graft.v1.SyncStatus.problems:type_name -> graft.v1.SyncProblem
 	12, // 4: graft.v1.SyncStatus.staging_progress:type_name -> graft.v1.SyncStagingProgress
 	0,  // 5: graft.v1.ConnectionStatus.state:type_name -> graft.v1.ConnectionState
 	15, // 6: graft.v1.ConnectionStatus.sync_statuses:type_name -> graft.v1.SyncStatus
-	64, // 7: graft.v1.ConnectionStatus.port_forward_statuses:type_name -> graft.v1.PortForwardStatus
-	65, // 8: graft.v1.ListConnectionsResponse.connections:type_name -> graft.v1.ListConnectionsResponse.ConnectionsEntry
+	66, // 7: graft.v1.ConnectionStatus.port_forward_statuses:type_name -> graft.v1.PortForwardStatus
+	67, // 8: graft.v1.ListConnectionsResponse.connections:type_name -> graft.v1.ListConnectionsResponse.ConnectionsEntry
 	46, // 9: graft.v1.SessionSelectConnectionResponse.path_remappings:type_name -> graft.v1.PathRemapping
 	48, // 10: graft.v1.CommandForwardings.commands:type_name -> graft.v1.CommandForwarding
-	66, // 11: graft.v1.SessionShimmedCommandsResponse.destination_commands:type_name -> graft.v1.SessionShimmedCommandsResponse.DestinationCommandsEntry
+	68, // 11: graft.v1.SessionShimmedCommandsResponse.destination_commands:type_name -> graft.v1.SessionShimmedCommandsResponse.DestinationCommandsEntry
 	52, // 12: graft.v1.RunCommandRequest.start:type_name -> graft.v1.StartCommand
 	53, // 13: graft.v1.RunCommandRequest.env_var:type_name -> graft.v1.SetEnvVar
 	54, // 14: graft.v1.RunCommandRequest.window_change:type_name -> graft.v1.WindowChange
@@ -4048,33 +4174,35 @@ var file_graft_v1_graft_proto_depIdxs = []int32{
 	43, // 40: graft.v1.GraftService.SessionWhich:input_type -> graft.v1.SessionWhichRequest
 	50, // 41: graft.v1.GraftService.SessionShimmedCommands:input_type -> graft.v1.SessionShimmedCommandsRequest
 	45, // 42: graft.v1.GraftService.SessionSelectConnection:input_type -> graft.v1.SessionSelectConnectionRequest
-	55, // 43: graft.v1.GraftService.RunCommand:input_type -> graft.v1.RunCommandRequest
-	3,  // 44: graft.v1.GraftService.Status:output_type -> graft.v1.StatusResponse
-	5,  // 45: graft.v1.GraftService.Ping:output_type -> graft.v1.PingResponse
-	7,  // 46: graft.v1.GraftService.Shutdown:output_type -> graft.v1.ShutdownResponse
-	9,  // 47: graft.v1.GraftService.Restart:output_type -> graft.v1.RestartResponse
-	11, // 48: graft.v1.GraftService.OOBMessages:output_type -> graft.v1.OOBMessagesResponse
-	18, // 49: graft.v1.GraftService.ListConnections:output_type -> graft.v1.ListConnectionsResponse
-	20, // 50: graft.v1.GraftService.InitializeSSHConnection:output_type -> graft.v1.InitializeSSHConnectionResponse
-	22, // 51: graft.v1.GraftService.InitializeContainerConnection:output_type -> graft.v1.InitializeContainerConnectionResponse
-	24, // 52: graft.v1.GraftService.RemoveConnection:output_type -> graft.v1.RemoveConnectionResponse
-	26, // 53: graft.v1.GraftService.DiscoverCommands:output_type -> graft.v1.DiscoverCommandsResponse
-	28, // 54: graft.v1.GraftService.UpdateConnectionRoots:output_type -> graft.v1.UpdateConnectionRootsResponse
-	30, // 55: graft.v1.GraftService.UpdateConnectionForwardCommands:output_type -> graft.v1.UpdateConnectionForwardCommandsResponse
-	32, // 56: graft.v1.GraftService.RemoveConnectionForwardCommands:output_type -> graft.v1.RemoveConnectionForwardCommandsResponse
-	34, // 57: graft.v1.GraftService.SyncFilesToConnection:output_type -> graft.v1.SyncFilesToConnectionResponse
-	38, // 58: graft.v1.GraftService.DumpLogs:output_type -> graft.v1.DumpLogsResponse
-	36, // 59: graft.v1.GraftService.SyncFilesToConnectionProtocol:output_type -> graft.v1.SyncFilesToConnectionProtocolResponse
-	40, // 60: graft.v1.GraftService.ForwardSSHAgent:output_type -> graft.v1.ForwardSSHAgentResponse
-	60, // 61: graft.v1.GraftService.WatchPorts:output_type -> graft.v1.WatchPortsResponse
-	63, // 62: graft.v1.GraftService.ForwardPort:output_type -> graft.v1.ForwardPortResponse
-	42, // 63: graft.v1.GraftService.SessionReportCWD:output_type -> graft.v1.SessionReportCWDResponse
-	44, // 64: graft.v1.GraftService.SessionWhich:output_type -> graft.v1.SessionWhichResponse
-	51, // 65: graft.v1.GraftService.SessionShimmedCommands:output_type -> graft.v1.SessionShimmedCommandsResponse
-	47, // 66: graft.v1.GraftService.SessionSelectConnection:output_type -> graft.v1.SessionSelectConnectionResponse
-	57, // 67: graft.v1.GraftService.RunCommand:output_type -> graft.v1.RunCommandResponse
-	44, // [44:68] is the sub-list for method output_type
-	20, // [20:44] is the sub-list for method input_type
+	64, // 43: graft.v1.GraftService.SessionPinConnection:input_type -> graft.v1.SessionPinConnectionRequest
+	55, // 44: graft.v1.GraftService.RunCommand:input_type -> graft.v1.RunCommandRequest
+	3,  // 45: graft.v1.GraftService.Status:output_type -> graft.v1.StatusResponse
+	5,  // 46: graft.v1.GraftService.Ping:output_type -> graft.v1.PingResponse
+	7,  // 47: graft.v1.GraftService.Shutdown:output_type -> graft.v1.ShutdownResponse
+	9,  // 48: graft.v1.GraftService.Restart:output_type -> graft.v1.RestartResponse
+	11, // 49: graft.v1.GraftService.OOBMessages:output_type -> graft.v1.OOBMessagesResponse
+	18, // 50: graft.v1.GraftService.ListConnections:output_type -> graft.v1.ListConnectionsResponse
+	20, // 51: graft.v1.GraftService.InitializeSSHConnection:output_type -> graft.v1.InitializeSSHConnectionResponse
+	22, // 52: graft.v1.GraftService.InitializeContainerConnection:output_type -> graft.v1.InitializeContainerConnectionResponse
+	24, // 53: graft.v1.GraftService.RemoveConnection:output_type -> graft.v1.RemoveConnectionResponse
+	26, // 54: graft.v1.GraftService.DiscoverCommands:output_type -> graft.v1.DiscoverCommandsResponse
+	28, // 55: graft.v1.GraftService.UpdateConnectionRoots:output_type -> graft.v1.UpdateConnectionRootsResponse
+	30, // 56: graft.v1.GraftService.UpdateConnectionForwardCommands:output_type -> graft.v1.UpdateConnectionForwardCommandsResponse
+	32, // 57: graft.v1.GraftService.RemoveConnectionForwardCommands:output_type -> graft.v1.RemoveConnectionForwardCommandsResponse
+	34, // 58: graft.v1.GraftService.SyncFilesToConnection:output_type -> graft.v1.SyncFilesToConnectionResponse
+	38, // 59: graft.v1.GraftService.DumpLogs:output_type -> graft.v1.DumpLogsResponse
+	36, // 60: graft.v1.GraftService.SyncFilesToConnectionProtocol:output_type -> graft.v1.SyncFilesToConnectionProtocolResponse
+	40, // 61: graft.v1.GraftService.ForwardSSHAgent:output_type -> graft.v1.ForwardSSHAgentResponse
+	60, // 62: graft.v1.GraftService.WatchPorts:output_type -> graft.v1.WatchPortsResponse
+	63, // 63: graft.v1.GraftService.ForwardPort:output_type -> graft.v1.ForwardPortResponse
+	42, // 64: graft.v1.GraftService.SessionReportCWD:output_type -> graft.v1.SessionReportCWDResponse
+	44, // 65: graft.v1.GraftService.SessionWhich:output_type -> graft.v1.SessionWhichResponse
+	51, // 66: graft.v1.GraftService.SessionShimmedCommands:output_type -> graft.v1.SessionShimmedCommandsResponse
+	47, // 67: graft.v1.GraftService.SessionSelectConnection:output_type -> graft.v1.SessionSelectConnectionResponse
+	65, // 68: graft.v1.GraftService.SessionPinConnection:output_type -> graft.v1.SessionPinConnectionResponse
+	57, // 69: graft.v1.GraftService.RunCommand:output_type -> graft.v1.RunCommandResponse
+	45, // [45:70] is the sub-list for method output_type
+	20, // [20:45] is the sub-list for method input_type
 	20, // [20:20] is the sub-list for extension type_name
 	20, // [20:20] is the sub-list for extension extendee
 	0,  // [0:20] is the sub-list for field type_name
@@ -4111,7 +4239,7 @@ func file_graft_v1_graft_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_graft_v1_graft_proto_rawDesc), len(file_graft_v1_graft_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   66,
+			NumMessages:   68,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/graft/v1/graft_grpc.pb.go
+++ b/gen/proto/graft/v1/graft_grpc.pb.go
@@ -42,6 +42,7 @@ const (
 	GraftService_SessionWhich_FullMethodName                    = "/graft.v1.GraftService/SessionWhich"
 	GraftService_SessionShimmedCommands_FullMethodName          = "/graft.v1.GraftService/SessionShimmedCommands"
 	GraftService_SessionSelectConnection_FullMethodName         = "/graft.v1.GraftService/SessionSelectConnection"
+	GraftService_SessionPinConnection_FullMethodName            = "/graft.v1.GraftService/SessionPinConnection"
 	GraftService_RunCommand_FullMethodName                      = "/graft.v1.GraftService/RunCommand"
 )
 
@@ -129,6 +130,8 @@ type GraftServiceClient interface {
 	SessionShimmedCommands(ctx context.Context, in *SessionShimmedCommandsRequest, opts ...grpc.CallOption) (*SessionShimmedCommandsResponse, error)
 	// SessionSelectConnection returns the best connection for session.
 	SessionSelectConnection(ctx context.Context, in *SessionSelectConnectionRequest, opts ...grpc.CallOption) (*SessionSelectConnectionResponse, error)
+	// SessionPinConnection pins a connection to a session, overriding CWD-based auto-selection.
+	SessionPinConnection(ctx context.Context, in *SessionPinConnectionRequest, opts ...grpc.CallOption) (*SessionPinConnectionResponse, error)
 	// RunCommand runs the given command on the daemon (locally or forwarded to remote) and exposes std[in/out/err] streams to use.
 	//
 	// Additionally, the client can control tty information like terminal resizing.
@@ -409,6 +412,16 @@ func (c *graftServiceClient) SessionSelectConnection(ctx context.Context, in *Se
 	return out, nil
 }
 
+func (c *graftServiceClient) SessionPinConnection(ctx context.Context, in *SessionPinConnectionRequest, opts ...grpc.CallOption) (*SessionPinConnectionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SessionPinConnectionResponse)
+	err := c.cc.Invoke(ctx, GraftService_SessionPinConnection_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *graftServiceClient) RunCommand(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[RunCommandRequest, RunCommandResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &GraftService_ServiceDesc.Streams[6], GraftService_RunCommand_FullMethodName, cOpts...)
@@ -506,6 +519,8 @@ type GraftServiceServer interface {
 	SessionShimmedCommands(context.Context, *SessionShimmedCommandsRequest) (*SessionShimmedCommandsResponse, error)
 	// SessionSelectConnection returns the best connection for session.
 	SessionSelectConnection(context.Context, *SessionSelectConnectionRequest) (*SessionSelectConnectionResponse, error)
+	// SessionPinConnection pins a connection to a session, overriding CWD-based auto-selection.
+	SessionPinConnection(context.Context, *SessionPinConnectionRequest) (*SessionPinConnectionResponse, error)
 	// RunCommand runs the given command on the daemon (locally or forwarded to remote) and exposes std[in/out/err] streams to use.
 	//
 	// Additionally, the client can control tty information like terminal resizing.
@@ -588,6 +603,9 @@ func (UnimplementedGraftServiceServer) SessionShimmedCommands(context.Context, *
 }
 func (UnimplementedGraftServiceServer) SessionSelectConnection(context.Context, *SessionSelectConnectionRequest) (*SessionSelectConnectionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SessionSelectConnection not implemented")
+}
+func (UnimplementedGraftServiceServer) SessionPinConnection(context.Context, *SessionPinConnectionRequest) (*SessionPinConnectionResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SessionPinConnection not implemented")
 }
 func (UnimplementedGraftServiceServer) RunCommand(grpc.BidiStreamingServer[RunCommandRequest, RunCommandResponse]) error {
 	return status.Error(codes.Unimplemented, "method RunCommand not implemented")
@@ -973,6 +991,24 @@ func _GraftService_SessionSelectConnection_Handler(srv interface{}, ctx context.
 	return interceptor(ctx, in, info, handler)
 }
 
+func _GraftService_SessionPinConnection_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SessionPinConnectionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(GraftServiceServer).SessionPinConnection(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: GraftService_SessionPinConnection_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(GraftServiceServer).SessionPinConnection(ctx, req.(*SessionPinConnectionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _GraftService_RunCommand_Handler(srv interface{}, stream grpc.ServerStream) error {
 	return srv.(GraftServiceServer).RunCommand(&grpc.GenericServerStream[RunCommandRequest, RunCommandResponse]{ServerStream: stream})
 }
@@ -1054,6 +1090,10 @@ var GraftService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SessionSelectConnection",
 			Handler:    _GraftService_SessionSelectConnection_Handler,
+		},
+		{
+			MethodName: "SessionPinConnection",
+			Handler:    _GraftService_SessionPinConnection_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -129,6 +129,8 @@ type ConnectionConfig struct {
 	// A list of file synchronizations for this connection. It's unclear what problems, if any, occur if there are overlapping
 	// intents.
 	Synchronizations []SynchronizationIntentConfig `yaml:"synchronizations"`
+	// Whether this connection is a background connection, excluded from CWD-based auto-selection.
+	Background bool `yaml:"background,omitempty"`
 }
 
 var errConnectionConfigDuplicateForwarding = errors.NewBare("connection duplicate forwarding detected")

--- a/pkg/connection.go
+++ b/pkg/connection.go
@@ -53,6 +53,7 @@ type Connection struct {
 	name       string
 	localRoot  string
 	remoteRoot string
+	background bool
 
 	mu               sync.Mutex
 	stateHash        uint32
@@ -62,14 +63,20 @@ type Connection struct {
 }
 
 // newConnection creates a connection backed by the given daemon.
-func newConnection(daemon *remoteDaemon, name, localRoot, remoteRoot string) *Connection {
+func newConnection(daemon *remoteDaemon, name, localRoot, remoteRoot string, background bool) *Connection {
 	return &Connection{
 		daemon:           daemon,
 		name:             name,
 		localRoot:        localRoot,
 		remoteRoot:       remoteRoot,
+		background:       background,
 		synchronizations: map[string]activeSync{},
 	}
+}
+
+// Background returns whether this is a background connection excluded from CWD-based auto-selection.
+func (conn *Connection) Background() bool {
+	return conn.background
 }
 
 // RunCommand runs a command on the remote daemon.

--- a/pkg/connection_manager.go
+++ b/pkg/connection_manager.go
@@ -96,16 +96,54 @@ func (mgr *ConnectionManager) getOrCreateDaemonForConnection(
 	return daemon, nil, nil
 }
 
+var errOverlappingLocalRoot = errors.NewBare("local root overlaps with existing connection")
+
 // createConnection creates a new connection backed by the given daemon and registers it.
-func (mgr *ConnectionManager) createConnection(name, localRoot, remoteRoot string, daemon *remoteDaemon) *Connection {
+// It returns an error if a non-background connection's local root overlaps with an
+// existing non-background connection's local root.
+func (mgr *ConnectionManager) createConnection(
+	name, localRoot, remoteRoot string, daemon *remoteDaemon, background bool,
+) (*Connection, error) {
 	mgr.connMgrMu.Lock()
 	defer mgr.connMgrMu.Unlock()
 
-	conn := newConnection(daemon, name, localRoot, remoteRoot)
+	if !background && localRoot != "" {
+		if err := mgr.checkOverlappingRoots(localRoot); err != nil {
+			return nil, err
+		}
+	}
+
+	conn := newConnection(daemon, name, localRoot, remoteRoot, background)
 	mgr.connections[name] = conn
 	mgr.writeConnectionRootsFile()
 
-	return conn
+	return conn, nil
+}
+
+// checkOverlappingRoots checks whether localRoot overlaps with any existing non-background
+// connection's local root. Must be called with connMgrMu held.
+func (mgr *ConnectionManager) checkOverlappingRoots(localRoot string) error {
+	newRoot := strings.ToLower(localRoot)
+
+	for _, conn := range mgr.connections {
+		if conn.background || conn.localRoot == "" {
+			continue
+		}
+
+		existingRoot := strings.ToLower(conn.localRoot)
+
+		if _, ok := hasPathPrefix(newRoot, existingRoot); ok {
+			return errors.WrapSuffix(errOverlappingLocalRoot,
+				fmt.Sprintf("'%s' overlaps with connection '%s' (%s)", localRoot, conn.name, conn.localRoot))
+		}
+
+		if _, ok := hasPathPrefix(existingRoot, newRoot); ok {
+			return errors.WrapSuffix(errOverlappingLocalRoot,
+				fmt.Sprintf("'%s' overlaps with connection '%s' (%s)", localRoot, conn.name, conn.localRoot))
+		}
+	}
+
+	return nil
 }
 
 // reassignDaemon re-keys a daemon after URL resolution (e.g. SSH config resolution
@@ -259,6 +297,7 @@ func (mgr *ConnectionManager) initialize(
 	remoteRoot string,
 	identity string,
 	destroyIfFail bool,
+	background bool,
 ) (*Connection, error) {
 	scheme, err := mgr.scheme(destURL)
 	if err != nil {
@@ -280,7 +319,10 @@ func (mgr *ConnectionManager) initialize(
 	}
 
 	// Create the connection early so it is visible in Connections() during initialization.
-	conn := mgr.createConnection(name, localRoot, remoteRoot, daemon)
+	conn, err := mgr.createConnection(name, localRoot, remoteRoot, daemon, background)
+	if err != nil {
+		return nil, err
+	}
 
 	// Initialize the daemon. The first caller does the work; concurrent callers
 	// block until initialization completes. Already-Connected daemons return immediately.
@@ -316,17 +358,17 @@ func (mgr *ConnectionManager) initialize(
 
 // Initialize sets up a new connection with a daemon running at the given destination.
 func (mgr *ConnectionManager) Initialize(
-	ctx context.Context, name string, destURL *url.URL, localRoot, remoteRoot, identity string,
+	ctx context.Context, name string, destURL *url.URL, localRoot, remoteRoot, identity string, background bool,
 ) (*Connection, error) {
-	return mgr.initialize(ctx, name, destURL, localRoot, remoteRoot, identity, true)
+	return mgr.initialize(ctx, name, destURL, localRoot, remoteRoot, identity, true, background)
 }
 
 // Restore ensures a connection is re-established. It's similar to Initialize but will only ensure the connection's
 // daemon is running.
 func (mgr *ConnectionManager) Restore(
-	ctx context.Context, name string, destURL *url.URL, localRoot, remoteRoot, identity string,
+	ctx context.Context, name string, destURL *url.URL, localRoot, remoteRoot, identity string, background bool,
 ) (*Connection, error) {
-	return mgr.initialize(ctx, name, destURL, localRoot, remoteRoot, identity, false)
+	return mgr.initialize(ctx, name, destURL, localRoot, remoteRoot, identity, false, background)
 }
 
 var (
@@ -610,6 +652,10 @@ func (mgr *ConnectionManager) writeConnectionRootsFile() {
 	for _, name := range names {
 		conn := mgr.connections[name]
 
+		if conn.background {
+			continue
+		}
+
 		localRoot := conn.localRoot
 		if localRoot == "" {
 			continue
@@ -674,7 +720,13 @@ func (mgr *ConnectionManager) connectionByCWD(ctx context.Context, cwd string) (
 
 	cwd = strings.ToLower(cwd)
 
+	matches := make([]*Connection, 0, len(mgr.connections))
+
 	for _, conn := range mgr.connections {
+		if conn.background {
+			continue
+		}
+
 		localRoot := conn.LocalRoot()
 		if localRoot == "" {
 			continue
@@ -700,7 +752,24 @@ func (mgr *ConnectionManager) connectionByCWD(ctx context.Context, cwd string) (
 			continue
 		}
 
-		return conn, true
+		matches = append(matches, conn)
+	}
+
+	if len(matches) == 1 {
+		return matches[0], true
+	}
+
+	if len(matches) > 1 {
+		names := make([]string, len(matches))
+		for i, m := range matches {
+			names[i] = m.Name()
+		}
+
+		slog.WarnContext(ctx, "multiple connections match cwd; cannot auto-select",
+			"cwd", cwd,
+			"connections", names)
+
+		return nil, false
 	}
 
 	return nil, false

--- a/pkg/connection_manager_test.go
+++ b/pkg/connection_manager_test.go
@@ -23,7 +23,8 @@ func TestConnectionManagerConnectionsSnapshot(t *testing.T) {
 	// Add a connection directly to the map (simulating createConnection).
 	daemon := newRemoteDaemon(&noopConnector{})
 	daemon.runCtx = mgr.runCtx
-	conn := mgr.createConnection("test-conn", "/local", "/remote", daemon)
+	conn, err := mgr.createConnection("test-conn", "/local", "/remote", daemon, false)
+	test.That(t, err, test.ShouldBeNil)
 
 	// Connections() returns the connection.
 	conns = mgr.Connections()
@@ -66,7 +67,7 @@ func TestConnectionManagerConnectionVisibleDuringInit(t *testing.T) {
 	initDone := make(chan error, 1)
 
 	go func() {
-		_, err := mgr.Restore(t.Context(), "myconn", destURL, "/local", "/remote", "")
+		_, err := mgr.Restore(t.Context(), "myconn", destURL, "/local", "/remote", "", false)
 		initDone <- err
 	}()
 
@@ -102,7 +103,7 @@ func TestConnectionManagerFailedInitDestroyIfFailRemovesConnection(t *testing.T)
 	test.That(t, err, test.ShouldBeNil)
 
 	// Initialize (destroyIfFail=true) should fail and remove connection from map.
-	_, initErr := mgr.Initialize(t.Context(), "myconn", destURL, "/local", "/remote", "")
+	_, initErr := mgr.Initialize(t.Context(), "myconn", destURL, "/local", "/remote", "", false)
 	test.That(t, initErr, test.ShouldNotBeNil)
 
 	conns := mgr.Connections()
@@ -125,7 +126,7 @@ func TestConnectionManagerFailedInitRestoreLeavesConnection(t *testing.T) {
 	test.That(t, err, test.ShouldBeNil)
 
 	// Restore (destroyIfFail=false) should fail but leave connection in map.
-	_, restoreErr := mgr.Restore(t.Context(), "myconn", destURL, "/local", "/remote", "")
+	_, restoreErr := mgr.Restore(t.Context(), "myconn", destURL, "/local", "/remote", "", false)
 	test.That(t, restoreErr, test.ShouldNotBeNil)
 
 	conns := mgr.Connections()
@@ -144,7 +145,8 @@ func TestConnectionManagerRemoveForwardCommands(t *testing.T) {
 		daemon := newRemoteDaemon(&noopConnector{})
 		daemon.runCtx = mgr.runCtx
 		daemon.setState(ConnectionStateConnected)
-		conn := mgr.createConnection("test-conn", "/local", "/remote", daemon)
+		conn, createErr := mgr.createConnection("test-conn", "/local", "/remote", daemon, false)
+		test.That(t, createErr, test.ShouldBeNil)
 		conn.UpdateForwardCommands([]ForwardCommandIntent{
 			{Name: "go", Prefix: false},
 			{Name: "python", Prefix: false},
@@ -293,7 +295,7 @@ func TestRunRecreatesConnectionRootsFile(t *testing.T) {
 
 	daemon := newRemoteDaemon(&noopConnector{})
 	daemon.runCtx = runCtx
-	mgr.connections["dev"] = newConnection(daemon, "dev", "/home/user/project", "/remote")
+	mgr.connections["dev"] = newConnection(daemon, "dev", "/home/user/project", "/remote", false)
 
 	// Write the file initially.
 	mgr.connMgrMu.Lock()
@@ -314,4 +316,193 @@ func TestRunRecreatesConnectionRootsFile(t *testing.T) {
 	data, err := os.ReadFile(mgr.connectionRootsPath)
 	test.That(t, err, test.ShouldBeNil)
 	test.That(t, string(data), test.ShouldEqual, "/home/user/project\tdev\n")
+}
+
+func TestConnectionByCWDSkipsBackground(t *testing.T) {
+	localRoot := t.TempDir()
+	subDir := filepath.Join(localRoot, "src")
+	test.That(t, os.MkdirAll(subDir, DirPerms), test.ShouldBeNil)
+
+	mgr := &ConnectionManager{
+		connections: map[string]*Connection{},
+	}
+	mgr.connections["bg"] = &Connection{name: "bg", localRoot: localRoot, background: true}
+
+	_, ok := mgr.connectionByCWD(context.Background(), subDir)
+	test.That(t, ok, test.ShouldBeFalse)
+}
+
+func TestConnectionByCWDBackgroundStillExplicitlyUsable(t *testing.T) {
+	mgr := NewConnectionManager()
+	defer mgr.Close()
+
+	daemon := newRemoteDaemon(&noopConnector{})
+	daemon.runCtx = mgr.runCtx
+	daemon.setState(ConnectionStateConnected)
+	_, createErr := mgr.createConnection("bg-conn", "/local", "/remote", daemon, true)
+	test.That(t, createErr, test.ShouldBeNil)
+
+	conn, err := mgr.Connection("bg-conn")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, conn.Name(), test.ShouldEqual, "bg-conn")
+	test.That(t, conn.Background(), test.ShouldBeTrue)
+}
+
+func TestWriteConnectionRootsFileExcludesBackground(t *testing.T) {
+	rootDir := t.TempDir()
+	mgr := &ConnectionManager{
+		connections:         map[string]*Connection{},
+		connectionRootsPath: filepath.Join(rootDir, connectionRootsFileName),
+	}
+
+	mgr.connections["fg"] = &Connection{name: "fg", localRoot: "/home/user/project"}
+	mgr.connections["bg"] = &Connection{name: "bg", localRoot: "/home/user/monorepo", background: true}
+	mgr.writeConnectionRootsFile()
+
+	data, err := os.ReadFile(mgr.connectionRootsPath)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, string(data), test.ShouldEqual, "/home/user/project\tfg\n")
+}
+
+func TestConnectionByCWD(t *testing.T) {
+	t.Run("single connection matches", func(t *testing.T) {
+		localRoot := t.TempDir()
+		subDir := filepath.Join(localRoot, "src")
+		test.That(t, os.MkdirAll(subDir, DirPerms), test.ShouldBeNil)
+
+		mgr := &ConnectionManager{
+			connections: map[string]*Connection{},
+		}
+		mgr.connections["dev"] = &Connection{name: "dev", localRoot: localRoot}
+
+		conn, ok := mgr.connectionByCWD(context.Background(), subDir)
+		test.That(t, ok, test.ShouldBeTrue)
+		test.That(t, conn.Name(), test.ShouldEqual, "dev")
+	})
+
+	t.Run("multiple matches returns false", func(t *testing.T) {
+		wsRoot := t.TempDir()
+		projRoot := filepath.Join(wsRoot, "infra", "anvil")
+		projSubDir := filepath.Join(projRoot, "src")
+		test.That(t, os.MkdirAll(projSubDir, DirPerms), test.ShouldBeNil)
+
+		mgr := &ConnectionManager{
+			connections: map[string]*Connection{},
+		}
+		mgr.connections["workspace"] = &Connection{name: "workspace", localRoot: wsRoot}
+		mgr.connections["anvil"] = &Connection{name: "anvil", localRoot: projRoot}
+
+		// Both connections match projSubDir - should refuse to auto-select.
+		_, ok := mgr.connectionByCWD(context.Background(), projSubDir)
+		test.That(t, ok, test.ShouldBeFalse)
+	})
+
+	t.Run("no match when cwd is outside all roots", func(t *testing.T) {
+		localRoot := t.TempDir()
+		otherDir := t.TempDir()
+
+		mgr := &ConnectionManager{
+			connections: map[string]*Connection{},
+		}
+		mgr.connections["dev"] = &Connection{name: "dev", localRoot: localRoot}
+
+		_, ok := mgr.connectionByCWD(context.Background(), otherDir)
+		test.That(t, ok, test.ShouldBeFalse)
+	})
+
+	t.Run("empty cwd returns no match", func(t *testing.T) {
+		mgr := &ConnectionManager{
+			connections: map[string]*Connection{},
+		}
+		mgr.connections["dev"] = &Connection{name: "dev", localRoot: "/some/path"}
+
+		_, ok := mgr.connectionByCWD(context.Background(), "")
+		test.That(t, ok, test.ShouldBeFalse)
+	})
+}
+
+func TestCreateConnectionRejectsOverlappingRoots(t *testing.T) {
+	t.Run("new root is parent of existing", func(t *testing.T) {
+		parentRoot := t.TempDir()
+		childRoot := filepath.Join(parentRoot, "child")
+		test.That(t, os.MkdirAll(childRoot, DirPerms), test.ShouldBeNil)
+
+		mgr := NewConnectionManager()
+		defer mgr.Close()
+
+		daemon := newRemoteDaemon(&noopConnector{})
+		daemon.runCtx = mgr.runCtx
+		_, err := mgr.createConnection("child-conn", childRoot, "/remote", daemon, false)
+		test.That(t, err, test.ShouldBeNil)
+
+		_, err = mgr.createConnection("parent-conn", parentRoot, "/remote2", daemon, false)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "overlaps")
+	})
+
+	t.Run("new root is child of existing", func(t *testing.T) {
+		parentRoot := t.TempDir()
+		childRoot := filepath.Join(parentRoot, "child")
+		test.That(t, os.MkdirAll(childRoot, DirPerms), test.ShouldBeNil)
+
+		mgr := NewConnectionManager()
+		defer mgr.Close()
+
+		daemon := newRemoteDaemon(&noopConnector{})
+		daemon.runCtx = mgr.runCtx
+		_, err := mgr.createConnection("parent-conn", parentRoot, "/remote", daemon, false)
+		test.That(t, err, test.ShouldBeNil)
+
+		_, err = mgr.createConnection("child-conn", childRoot, "/remote2", daemon, false)
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, err.Error(), test.ShouldContainSubstring, "overlaps")
+	})
+
+	t.Run("background connections do not conflict", func(t *testing.T) {
+		parentRoot := t.TempDir()
+		childRoot := filepath.Join(parentRoot, "child")
+		test.That(t, os.MkdirAll(childRoot, DirPerms), test.ShouldBeNil)
+
+		mgr := NewConnectionManager()
+		defer mgr.Close()
+
+		daemon := newRemoteDaemon(&noopConnector{})
+		daemon.runCtx = mgr.runCtx
+		_, err := mgr.createConnection("fg-conn", childRoot, "/remote", daemon, false)
+		test.That(t, err, test.ShouldBeNil)
+
+		_, err = mgr.createConnection("bg-conn", parentRoot, "/remote2", daemon, true)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("non-overlapping roots are fine", func(t *testing.T) {
+		rootA := t.TempDir()
+		rootB := t.TempDir()
+
+		mgr := NewConnectionManager()
+		defer mgr.Close()
+
+		daemon := newRemoteDaemon(&noopConnector{})
+		daemon.runCtx = mgr.runCtx
+		_, err := mgr.createConnection("connA", rootA, "/remote", daemon, false)
+		test.That(t, err, test.ShouldBeNil)
+
+		_, err = mgr.createConnection("connB", rootB, "/remote2", daemon, false)
+		test.That(t, err, test.ShouldBeNil)
+	})
+
+	t.Run("empty root never conflicts", func(t *testing.T) {
+		root := t.TempDir()
+
+		mgr := NewConnectionManager()
+		defer mgr.Close()
+
+		daemon := newRemoteDaemon(&noopConnector{})
+		daemon.runCtx = mgr.runCtx
+		_, err := mgr.createConnection("connA", root, "/remote", daemon, false)
+		test.That(t, err, test.ShouldBeNil)
+
+		_, err = mgr.createConnection("connB", "", "/remote2", daemon, false)
+		test.That(t, err, test.ShouldBeNil)
+	})
 }

--- a/pkg/connection_reconnect_test.go
+++ b/pkg/connection_reconnect_test.go
@@ -138,6 +138,7 @@ func (m *mockReconnectConnector) Close() error {
 	return nil
 }
 
+// TODO(erd): unify with newRemoteDaemon so tests exercise real construction.
 func newTestDaemon(t *testing.T, connector *mockReconnectConnector) *remoteDaemon {
 	t.Helper()
 
@@ -303,7 +304,7 @@ func TestConnectionStateDerivedFromDaemon(t *testing.T) {
 	connector := &mockReconnectConnector{destination: "test://host"}
 	daemon := newTestDaemon(t, connector)
 
-	conn := newConnection(daemon, "myconn", "/local", "/remote")
+	conn := newConnection(daemon, "myconn", "/local", "/remote", false)
 
 	// Connection derives Connected from daemon.
 	state, _ := conn.State()

--- a/pkg/connection_test.go
+++ b/pkg/connection_test.go
@@ -7,10 +7,11 @@ import (
 	"go.viam.com/test"
 )
 
+// TODO(erd): unify with newConnection so tests exercise the real creation path.
 func newTestConnectionWithRoots(localRoot, remoteRoot string) *Connection {
 	daemon := newRemoteDaemon(&noopConnector{})
 
-	return newConnection(daemon, "test", localRoot, remoteRoot)
+	return newConnection(daemon, "test", localRoot, remoteRoot, false)
 }
 
 func TestMatchCWD(t *testing.T) {

--- a/pkg/e2e_docker_test.go
+++ b/pkg/e2e_docker_test.go
@@ -139,7 +139,7 @@ func TestConnectionManagerE2E(t *testing.T) {
 
 			localRoot := t.TempDir()
 
-			conn, err := mgr.Initialize(t.Context(), connName, v.destURL, localRoot, "", "")
+			conn, err := mgr.Initialize(t.Context(), connName, v.destURL, localRoot, "", "", false)
 			test.That(t, err, test.ShouldBeNil)
 
 			t.Cleanup(func() {
@@ -177,7 +177,7 @@ func TestMultipleConnectionsSameIdentityE2E(t *testing.T) {
 	connName2 := sanitizeContainerName("graft-e2e-sameid2-" + t.Name())
 
 	// First connection installs and starts the remote daemon.
-	conn1, err := mgr.Initialize(t.Context(), connName1, destURL, t.TempDir(), "/tmp/proj1", identity)
+	conn1, err := mgr.Initialize(t.Context(), connName1, destURL, t.TempDir(), "/tmp/proj1", identity, false)
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Cleanup(func() {
@@ -200,7 +200,7 @@ func TestMultipleConnectionsSameIdentityE2E(t *testing.T) {
 	t.Cleanup(func() { ourVersion = savedVersion })
 
 	// Second connection with the same identity reuses the existing remote daemon.
-	conn2, err := mgr.Initialize(t.Context(), connName2, destURL, t.TempDir(), "/tmp/proj2", identity)
+	conn2, err := mgr.Initialize(t.Context(), connName2, destURL, t.TempDir(), "/tmp/proj2", identity, false)
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Cleanup(func() {
@@ -269,7 +269,7 @@ func TestMultipleConnectionsDifferentIdentitiesE2E(t *testing.T) {
 	connName2 := sanitizeContainerName("graft-e2e-diffid2-" + t.Name())
 
 	// First connection with identity "alpha".
-	conn1, err := mgr.Initialize(t.Context(), connName1, destURL, t.TempDir(), "/tmp/proj1", "test-alpha-aa11")
+	conn1, err := mgr.Initialize(t.Context(), connName1, destURL, t.TempDir(), "/tmp/proj1", "test-alpha-aa11", false)
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Cleanup(func() {
@@ -280,7 +280,7 @@ func TestMultipleConnectionsDifferentIdentitiesE2E(t *testing.T) {
 	test.That(t, state1, test.ShouldEqual, ConnectionStateConnected)
 
 	// Second connection with identity "bravo" - separate remote daemon instance.
-	conn2, err := mgr.Initialize(t.Context(), connName2, destURL, t.TempDir(), "/tmp/proj2", "test-bravo-bb22")
+	conn2, err := mgr.Initialize(t.Context(), connName2, destURL, t.TempDir(), "/tmp/proj2", "test-bravo-bb22", false)
 	test.That(t, err, test.ShouldBeNil)
 
 	t.Cleanup(func() {
@@ -764,7 +764,7 @@ func TestConnectionReconnectE2E(t *testing.T) {
 
 			localRoot := t.TempDir()
 
-			conn, err := mgr.Initialize(t.Context(), connName, v.destURL, localRoot, "", "")
+			conn, err := mgr.Initialize(t.Context(), connName, v.destURL, localRoot, "", "", false)
 			test.That(t, err, test.ShouldBeNil)
 
 			t.Cleanup(func() {

--- a/pkg/local_client_commands.go
+++ b/pkg/local_client_commands.go
@@ -284,6 +284,9 @@ type ConnectParams struct {
 	// SyncSource/SyncDest override LocalRoot/RemoteRoot for sync when set.
 	SyncSource string
 	SyncDest   string
+
+	// Background excludes this connection from CWD-based auto-selection.
+	Background bool
 }
 
 // InitializeRemoteConnection sets up an SSH based connection.
@@ -308,6 +311,7 @@ func (client *LocalClient) InitializeRemoteConnection(ctx context.Context, param
 		Pid:         uint64(os.Getppid()), //nolint:gosec // overflow okay
 		LocalRoot:   params.LocalRoot,
 		RemoteRoot:  params.RemoteRoot,
+		Background:  params.Background,
 	})
 	if err != nil {
 		return client.handleError(err)
@@ -328,6 +332,7 @@ func (client *LocalClient) InitializeDockerConnection(ctx context.Context, param
 		OperatingSystem: params.OSName,
 		LocalRoot:       params.LocalRoot,
 		RemoteRoot:      params.RemoteRoot,
+		Background:      params.Background,
 	})
 	if err != nil {
 		return client.handleError(err)
@@ -733,6 +738,24 @@ func (client *LocalClient) Which(ctx context.Context, cmd string) error {
 	}
 
 	fmt.Fprintf(client.errWriter, "%s: %s\n", resp.GetConnectionName(), resp.GetRemotePath())
+
+	return nil
+}
+
+// PinConnection pins a connection to the current session.
+func (client *LocalClient) PinConnection(ctx context.Context, connName string) error {
+	sessPID, ok := client.sessionPID()
+	if !ok {
+		sessPID = uint64(os.Getppid()) //nolint:gosec // overflow okay
+	}
+
+	_, err := client.SessionPinConnection(ctx, &graftv1.SessionPinConnectionRequest{
+		Pid:            sessPID,
+		ConnectionName: connName,
+	})
+	if err != nil {
+		return client.handleError(err)
+	}
 
 	return nil
 }

--- a/pkg/remote_daemon_test.go
+++ b/pkg/remote_daemon_test.go
@@ -387,8 +387,8 @@ func TestRemoteDaemonInstallGuard(t *testing.T) {
 	t.Run("shared across connections", func(t *testing.T) {
 		daemon := newRemoteDaemon(&noopConnector{})
 
-		conn1 := newConnection(daemon, "conn1", "", "")
-		conn2 := newConnection(daemon, "conn2", "", "")
+		conn1 := newConnection(daemon, "conn1", "", "", false)
+		conn2 := newConnection(daemon, "conn2", "", "", false)
 
 		test.That(t, conn1.daemon.alreadyInstalled(), test.ShouldBeFalse)
 		test.That(t, conn2.daemon.alreadyInstalled(), test.ShouldBeFalse)

--- a/pkg/server.go
+++ b/pkg/server.go
@@ -243,7 +243,9 @@ func (srv *Server) restore(runCtx context.Context) error {
 
 			// TODO(erd): the restoration of this could probably be similar to initialization so that we don't
 			// need to write duplicate code.
-			if _, err := srv.connMgr.Restore(runCtx, conf.Name, destURL, conf.LocalRoot, conf.RemoteRoot, srv.identity); err != nil {
+			_, err = srv.connMgr.Restore(
+				runCtx, conf.Name, destURL, conf.LocalRoot, conf.RemoteRoot, srv.identity, conf.Background)
+			if err != nil {
 				slog.ErrorContext(runCtx, "error restoring connection", "name", conf.Name, "error", err)
 
 				errs <- err

--- a/pkg/server_grpc_connection.go
+++ b/pkg/server_grpc_connection.go
@@ -318,7 +318,9 @@ func (srv *Server) InitializeSSHConnection(
 	localRoot := req.GetLocalRoot()
 	remoteRoot := req.GetRemoteRoot()
 
-	conn, err := srv.connMgr.Initialize(ctx, name, destURL, localRoot, remoteRoot, srv.identity)
+	background := req.GetBackground()
+
+	conn, err := srv.connMgr.Initialize(ctx, name, destURL, localRoot, remoteRoot, srv.identity, background)
 	if err != nil {
 		return nil, err
 	}
@@ -329,6 +331,7 @@ func (srv *Server) InitializeSSHConnection(
 		Destination: conn.daemon.Destination(),
 		LocalRoot:   localRoot,
 		RemoteRoot:  remoteRoot,
+		Background:  background,
 	})
 	srv.persistConfig()
 
@@ -363,7 +366,9 @@ func (srv *Server) InitializeContainerConnection(
 	localRoot := req.GetLocalRoot()
 	remoteRoot := req.GetRemoteRoot()
 
-	conn, err := srv.connMgr.Initialize(ctx, name, &destURL, localRoot, remoteRoot, srv.identity)
+	background := req.GetBackground()
+
+	conn, err := srv.connMgr.Initialize(ctx, name, &destURL, localRoot, remoteRoot, srv.identity, background)
 	if err != nil {
 		return nil, err
 	}
@@ -373,6 +378,7 @@ func (srv *Server) InitializeContainerConnection(
 		Destination: conn.daemon.Destination(),
 		LocalRoot:   localRoot,
 		RemoteRoot:  remoteRoot,
+		Background:  background,
 	})
 	srv.persistConfig()
 

--- a/pkg/server_grpc_session.go
+++ b/pkg/server_grpc_session.go
@@ -42,7 +42,12 @@ func (srv *Server) SessionSelectConnection(
 		return nil, updateErr
 	}
 
-	conn, err := srv.sessMgr.selectConnection(ctx, "", req.GetCwd())
+	sess, err := srv.sessMgr.SessionByPID(req.GetPid())
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := srv.sessMgr.selectConnection(ctx, sess, "", req.GetCwd())
 	if err != nil {
 		return nil, err
 	}
@@ -67,6 +72,19 @@ func (srv *Server) SessionSelectConnection(
 	}
 
 	return resp, nil
+}
+
+// SessionPinConnection pins a connection to a session, overriding CWD-based auto-selection.
+func (srv *Server) SessionPinConnection(
+	ctx context.Context,
+	req *graftv1.SessionPinConnectionRequest,
+) (*graftv1.SessionPinConnectionResponse, error) {
+	connName, err := srv.sessMgr.PinConnection(ctx, req.GetPid(), req.GetConnectionName())
+	if err != nil {
+		return nil, err
+	}
+
+	return &graftv1.SessionPinConnectionResponse{ConnectionName: connName}, nil
 }
 
 // SessionShimmedCommands returns all commands that should be shimmed for a session across all established connections.

--- a/pkg/session.go
+++ b/pkg/session.go
@@ -14,12 +14,13 @@ import (
 // forwardings eventually get created as files that are in this session's PATH, if the shimming
 // utility is installed into the shell.
 type Session struct {
-	sessMu      sync.Mutex
-	desiredFwds map[string][]ForwardCommandIntent
-	actualFwds  map[string]ForwardedCommand
-	dir         string
-	shimPath    string
-	cwd         string
+	sessMu           sync.Mutex
+	desiredFwds      map[string][]ForwardCommandIntent
+	actualFwds       map[string]ForwardedCommand
+	dir              string
+	shimPath         string
+	cwd              string
+	pinnedConnection string
 }
 
 // A ForwardedCommand is a tuple of a path to a command and a connection that command can run on.
@@ -34,6 +35,22 @@ func (sess *Session) CWD() string {
 	defer sess.sessMu.Unlock()
 
 	return sess.cwd
+}
+
+// PinnedConnection returns the name of the pinned connection, or "" if none.
+func (sess *Session) PinnedConnection() string {
+	sess.sessMu.Lock()
+	defer sess.sessMu.Unlock()
+
+	return sess.pinnedConnection
+}
+
+// SetPinnedConnection sets or clears the pinned connection for this session.
+func (sess *Session) SetPinnedConnection(name string) {
+	sess.sessMu.Lock()
+	defer sess.sessMu.Unlock()
+
+	sess.pinnedConnection = name
 }
 
 // ShimPath returns the directory that shims are added to.

--- a/pkg/session_manager.go
+++ b/pkg/session_manager.go
@@ -222,12 +222,21 @@ func (mgr *SessionManager) tickReconcileSession(runCtx context.Context, sess *Se
 
 	shimCommand(runCtx, shimPath, sudoCommandName)
 
-	// Update current connection file for shell prompt
+	// Update current connection file for shell prompt.
+	// Pinned connection takes precedence over CWD-based selection.
 	connName := ""
 
-	if cwd := sess.CWD(); cwd != "" {
-		if conn, ok := mgr.connMgr.ConnectionByCWD(runCtx, cwd); ok {
-			connName = conn.Name()
+	if pinned := sess.PinnedConnection(); pinned != "" {
+		if _, err := mgr.connMgr.Connection(pinned); err == nil {
+			connName = pinned
+		}
+	}
+
+	if connName == "" {
+		if cwd := sess.CWD(); cwd != "" {
+			if conn, ok := mgr.connMgr.ConnectionByCWD(runCtx, cwd); ok {
+				connName = conn.Name()
+			}
 		}
 	}
 
@@ -472,6 +481,30 @@ func (mgr *SessionManager) UpdateSessionCWD(ctx context.Context, sessionPID uint
 	return nil
 }
 
+// PinConnection pins a connection to a session, overriding CWD-based auto-selection.
+// An empty connName clears the pin.
+func (mgr *SessionManager) PinConnection(ctx context.Context, sessionPID uint64, connName string) (string, error) {
+	if connName != "" {
+		if _, err := mgr.connMgr.Connection(connName); err != nil {
+			return "", err
+		}
+	}
+
+	mgr.sessMgrMu.Lock()
+	defer mgr.sessMgrMu.Unlock()
+
+	sess, err := mgr.getOrCreateSession(sessionPID)
+	if err != nil {
+		return "", err
+	}
+
+	sess.SetPinnedConnection(connName)
+
+	mgr.tickReconcileSession(ctx, sess)
+
+	return connName, nil
+}
+
 // Close does nothing for now.
 func (mgr *SessionManager) Close() {
 }
@@ -498,18 +531,28 @@ func (mgr *SessionManager) Which(
 }
 
 // selectConnection figures out which connection to use based on the current state of the system.
-//
-// TODO(erd): this needs work like DesiredForwardingsForSession does in terms of the best UX
-// for how to accomplish this. In the past, we just took the first session/connection found which
-// works in the simplest of cases. Ideally we start with something like a hierarchy of:
-// - connection name specified
-// - session set a default
-// - determine via cwd.
-func (mgr *SessionManager) selectConnection(ctx context.Context, connName string, cwd string) (*Connection, error) {
+// The selection hierarchy is:
+// 1. Explicit connection name
+// 2. Session-pinned connection (via `graft use`)
+// 3. CWD-based auto-selection.
+func (mgr *SessionManager) selectConnection(ctx context.Context, sess *Session, connName string, cwd string) (*Connection, error) {
 	slog.DebugContext(ctx, "lookup connection by name", "name", connName)
 
 	if connName != "" {
 		return mgr.connMgr.Connection(connName)
+	}
+
+	if sess != nil {
+		if pinned := sess.PinnedConnection(); pinned != "" {
+			slog.DebugContext(ctx, "lookup connection by session pin", "pinned", pinned)
+
+			conn, err := mgr.connMgr.Connection(pinned)
+			if err == nil {
+				return conn, nil
+			}
+
+			slog.WarnContext(ctx, "pinned connection unavailable; falling through to CWD", "pinned", pinned, "error", err)
+		}
 	}
 
 	slog.DebugContext(ctx, "lookup connection by cwd", "cwd", cwd)
@@ -524,8 +567,10 @@ func (mgr *SessionManager) selectConnection(ctx context.Context, connName string
 	return nil, errors.New("no connection to start a shell with by default")
 }
 
-func (mgr *SessionManager) selectConnectionForCommand(ctx context.Context, connName, command, cwd string) (ForwardedCommand, error) {
-	conn, selectErr := mgr.selectConnection(ctx, connName, cwd)
+func (mgr *SessionManager) selectConnectionForCommand(
+	ctx context.Context, sess *Session, connName, command, cwd string,
+) (ForwardedCommand, error) {
+	conn, selectErr := mgr.selectConnection(ctx, sess, connName, cwd)
 	if selectErr != nil {
 		return ForwardedCommand{}, selectErr
 	}
@@ -604,7 +649,7 @@ func (mgr *SessionManager) RunCommand(
 	// path to the command on the remote side.
 	if exactCommand || shell {
 		// TODO(erd): Protect against race condition when reading sess.cwd.
-		selected, selectErr := mgr.selectConnectionForCommand(runCtx, connectionName, command, sess.cwd)
+		selected, selectErr := mgr.selectConnectionForCommand(runCtx, sess, connectionName, command, sess.cwd)
 		if selectErr != nil {
 			return nil, selectErr
 		}

--- a/pkg/session_manager_test.go
+++ b/pkg/session_manager_test.go
@@ -62,17 +62,22 @@ func TestWriteSessionConnectionFile(t *testing.T) {
 	})
 }
 
-func TestUpdateSessionCWDReconciles(t *testing.T) {
-	localRoot := t.TempDir()
-
-	connMgr := &ConnectionManager{
-		connections:         map[string]*Connection{},
-		connectionRootsPath: filepath.Join(t.TempDir(), connectionRootsFileName),
-	}
-	connMgr.connections["myconn"] = &Connection{
-		name:      "myconn",
+// TODO(erd): unify with newConnection so tests exercise the real creation path.
+func newTestConnection(name, localRoot string) *Connection {
+	return &Connection{
+		name:      name,
 		localRoot: localRoot,
 		daemon:    &remoteDaemon{state: ConnectionStateConnected},
+	}
+}
+
+// TODO(erd): unify with NewSessionManager/NewConnectionManager so tests exercise real construction.
+func newTestSessionManager(t *testing.T, conns map[string]*Connection) (*SessionManager, string) {
+	t.Helper()
+
+	connMgr := &ConnectionManager{
+		connections:         conns,
+		connectionRootsPath: filepath.Join(t.TempDir(), connectionRootsFileName),
 	}
 
 	sessionsRoot, err := SessionsRoot()
@@ -84,6 +89,16 @@ func TestUpdateSessionCWDReconciles(t *testing.T) {
 		rootPath: sessionsRoot,
 	}
 
+	return mgr, sessionsRoot
+}
+
+func TestUpdateSessionCWDReconciles(t *testing.T) {
+	localRoot := t.TempDir()
+
+	mgr, sessionsRoot := newTestSessionManager(t, map[string]*Connection{
+		"myconn": newTestConnection("myconn", localRoot),
+	})
+
 	// Use a PID unlikely to conflict with real processes.
 	pid := uint64(99999)
 
@@ -94,11 +109,158 @@ func TestUpdateSessionCWDReconciles(t *testing.T) {
 
 	// Call UpdateSessionCWD with a CWD inside the connection's local root.
 	ctx := context.Background()
-	err = mgr.UpdateSessionCWD(ctx, pid, localRoot)
+	err := mgr.UpdateSessionCWD(ctx, pid, localRoot)
 	test.That(t, err, test.ShouldBeNil)
 
 	// The current_connection file should be written immediately (no tick needed).
 	data, readErr := os.ReadFile(filepath.Join(sessPath, currentConnectionFileName))
 	test.That(t, readErr, test.ShouldBeNil)
 	test.That(t, string(data), test.ShouldEqual, "myconn")
+}
+
+func TestSelectConnectionUsesPin(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+
+	mgr, sessionsRoot := newTestSessionManager(t, map[string]*Connection{
+		"connA": newTestConnection("connA", rootA),
+		"connB": newTestConnection("connB", rootB),
+	})
+
+	pid := uint64(99990)
+	sessPath := SessionPathFromRoot(sessionsRoot, "99990")
+
+	t.Cleanup(func() { os.RemoveAll(sessPath) })
+
+	ctx := context.Background()
+
+	// CWD inside rootA normally resolves to connA.
+	err := mgr.UpdateSessionCWD(ctx, pid, rootA)
+	test.That(t, err, test.ShouldBeNil)
+
+	sess, err := mgr.SessionByPID(pid)
+	test.That(t, err, test.ShouldBeNil)
+
+	conn, err := mgr.selectConnection(ctx, sess, "", rootA)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, conn.Name(), test.ShouldEqual, "connA")
+
+	// Pin to connB - should override CWD.
+	sess.SetPinnedConnection("connB")
+	conn, err = mgr.selectConnection(ctx, sess, "", rootA)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, conn.Name(), test.ShouldEqual, "connB")
+}
+
+func TestSelectConnectionClearPin(t *testing.T) {
+	rootA := t.TempDir()
+
+	mgr, sessionsRoot := newTestSessionManager(t, map[string]*Connection{
+		"connA": newTestConnection("connA", rootA),
+		"connB": newTestConnection("connB", t.TempDir()),
+	})
+
+	pid := uint64(99989)
+	sessPath := SessionPathFromRoot(sessionsRoot, "99989")
+
+	t.Cleanup(func() { os.RemoveAll(sessPath) })
+
+	ctx := context.Background()
+	err := mgr.UpdateSessionCWD(ctx, pid, rootA)
+	test.That(t, err, test.ShouldBeNil)
+
+	sess, err := mgr.SessionByPID(pid)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Pin to connB, then clear.
+	sess.SetPinnedConnection("connB")
+	sess.SetPinnedConnection("")
+
+	conn, err := mgr.selectConnection(ctx, sess, "", rootA)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, conn.Name(), test.ShouldEqual, "connA")
+}
+
+func TestPinConnectionValidatesExists(t *testing.T) {
+	mgr, sessionsRoot := newTestSessionManager(t, map[string]*Connection{})
+
+	pid := uint64(99988)
+	sessPath := SessionPathFromRoot(sessionsRoot, "99988")
+
+	t.Cleanup(func() { os.RemoveAll(sessPath) })
+
+	ctx := context.Background()
+
+	_, err := mgr.PinConnection(ctx, pid, "nonexistent")
+	test.That(t, err, test.ShouldNotBeNil)
+}
+
+func TestTickReconcileSessionWithPin(t *testing.T) {
+	rootA := t.TempDir()
+
+	mgr, sessionsRoot := newTestSessionManager(t, map[string]*Connection{
+		"connA": newTestConnection("connA", rootA),
+		"connB": newTestConnection("connB", t.TempDir()),
+	})
+
+	pid := uint64(99987)
+	sessPath := SessionPathFromRoot(sessionsRoot, "99987")
+
+	t.Cleanup(func() { os.RemoveAll(sessPath) })
+
+	ctx := context.Background()
+
+	// Set CWD inside rootA.
+	err := mgr.UpdateSessionCWD(ctx, pid, rootA)
+	test.That(t, err, test.ShouldBeNil)
+
+	// Without pin, current_connection reflects CWD match.
+	data, readErr := os.ReadFile(filepath.Join(sessPath, currentConnectionFileName))
+	test.That(t, readErr, test.ShouldBeNil)
+	test.That(t, string(data), test.ShouldEqual, "connA")
+
+	// Pin to connB and reconcile.
+	_, err = mgr.PinConnection(ctx, pid, "connB")
+	test.That(t, err, test.ShouldBeNil)
+
+	data, readErr = os.ReadFile(filepath.Join(sessPath, currentConnectionFileName))
+	test.That(t, readErr, test.ShouldBeNil)
+	test.That(t, string(data), test.ShouldEqual, "connB")
+}
+
+func TestUpdateSessionCWDReconcileMultipleConnections(t *testing.T) {
+	wsRoot := t.TempDir()
+	projARoot := filepath.Join(wsRoot, "infra", "projectA")
+	projBRoot := filepath.Join(wsRoot, "infra", "projectB")
+
+	test.That(t, os.MkdirAll(projARoot, DirPerms), test.ShouldBeNil)
+	test.That(t, os.MkdirAll(projBRoot, DirPerms), test.ShouldBeNil)
+
+	mgr, sessionsRoot := newTestSessionManager(t, map[string]*Connection{
+		"connA": newTestConnection("connA", projARoot),
+		"connB": newTestConnection("connB", projBRoot),
+	})
+
+	pid := uint64(99998)
+	sessPath := SessionPathFromRoot(sessionsRoot, "99998")
+
+	t.Cleanup(func() { os.RemoveAll(sessPath) })
+
+	ctx := context.Background()
+
+	// CWD inside projectA should resolve to connA.
+	err := mgr.UpdateSessionCWD(ctx, pid, projARoot)
+	test.That(t, err, test.ShouldBeNil)
+
+	data, readErr := os.ReadFile(filepath.Join(sessPath, currentConnectionFileName))
+	test.That(t, readErr, test.ShouldBeNil)
+	test.That(t, string(data), test.ShouldEqual, "connA")
+
+	// CWD inside projectB should resolve to connB.
+	err = mgr.UpdateSessionCWD(ctx, pid, projBRoot)
+	test.That(t, err, test.ShouldBeNil)
+
+	data, readErr = os.ReadFile(filepath.Join(sessPath, currentConnectionFileName))
+	test.That(t, readErr, test.ShouldBeNil)
+	test.That(t, string(data), test.ShouldEqual, "connB")
 }

--- a/pkg/update_github_test.go
+++ b/pkg/update_github_test.go
@@ -15,6 +15,7 @@ import (
 	"go.viam.com/test"
 )
 
+// TODO(erd): unify with production GitHubReleaseClient constructor so tests exercise real construction.
 func newTestGitHubReleaseClient(t *testing.T) (*GitHubReleaseClient, *http.ServeMux) {
 	t.Helper()
 

--- a/proto/graft/v1/graft.proto
+++ b/proto/graft/v1/graft.proto
@@ -143,6 +143,9 @@ service GraftService {
   // SessionSelectConnection returns the best connection for session.
   rpc SessionSelectConnection(SessionSelectConnectionRequest) returns (SessionSelectConnectionResponse) {}
 
+  // SessionPinConnection pins a connection to a session, overriding CWD-based auto-selection.
+  rpc SessionPinConnection(SessionPinConnectionRequest) returns (SessionPinConnectionResponse) {}
+
   //
   // Command
   //
@@ -272,6 +275,7 @@ message InitializeSSHConnectionRequest {
   uint64 pid = 5;
   string local_root = 6;
   string remote_root = 7;
+  bool background = 8;
 }
 
 message InitializeSSHConnectionResponse {
@@ -286,6 +290,7 @@ message InitializeContainerConnectionRequest {
   string user_name = 5;
   string local_root = 6;
   string remote_root = 7;
+  bool background = 8;
 }
 
 message InitializeContainerConnectionResponse {
@@ -499,6 +504,15 @@ message ForwardPortStart {
 // ForwardPortResponse carries raw payload bytes from the remote back to local.
 message ForwardPortResponse {
   bytes payload = 1;
+}
+
+message SessionPinConnectionRequest {
+  uint64 pid = 1;
+  string connection_name = 2;
+}
+
+message SessionPinConnectionResponse {
+  string connection_name = 1;
 }
 
 // PortForwardStatus is the status of a single port forward, shown in `graft status`.


### PR DESCRIPTION
Improves multi-connection management for projects and workspaces:

- graft use: New command to pin a connection to the current shell session, overriding CWD-based auto-selection. graft use --clear resumes auto-selection.
- Connection selection hierarchy: explicit --to > session pin (graft use) > CWD-based matching.
- Background connections: graft connect --background excludes a connection from CWD auto-selection - only reachable via --to or graft use.
- Overlapping root detection: Non-background connections with overlapping local roots are rejected at creation time instead of silently breaking auto-selection.
- Ambiguous CWD handling: When multiple non-background connections match a CWD, auto-selection is refused instead of silently picking the first.
- Shell prompt fix: Prompt now reads the daemon-written current_connection file (which respects pins) instead of duplicating CWD matching logic in shell code.
- graft init rework: Now accepts `graft init <local_dir> <destination>[:<remote_dir>]` with --name, --sync, and --forward flags. Destination parsing is unified across init and connect.
- Project-level sync: New `sync` field in graft.yaml project config. Workspace sync takes precedence when present; otherwise the project's own sync: true is honored.

AI disclosure
- I used AI tools (details below)

AI tools used: Claude Code (Claude Opus 4.6)
How AI was used: Code generation, test writing, refactoring, code review, documentation drafting (so, like, a lot)