### PR TITLE
startup: move docker availability error to debug for now

### DIFF
--- a/pkg/server.go
+++ b/pkg/server.go
@@ -78,7 +78,7 @@ func NewServer(
 
 		dockerScheme, err := newDockerConnectorFactory(initializeContext)
 		if err != nil {
-			slog.ErrorContext(initializeContext, "docker not supported", "error", err)
+			slog.DebugContext(initializeContext, "docker not supported", "error", err)
 		} else {
 			connMgr.RegisterConnectorFactory(dockerSchemeName, dockerScheme)
 		}


### PR DESCRIPTION
It's low value with the stack trace in it at the moment. The tool is also mostly targeting ssh. I was using docker years ago for testing purposes but I'll probably focus on it more soonish.