### PR TITLE
sec: add security model section to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ graft use build          # explicitly switch to it
 
 See [docs/architecture.md](docs/architecture.md) for how graft works internally.
 
+## Security
+
+See [docs/architecture.md#security-model](docs/architecture.md#security-model).
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, including our [AI usage policy](CONTRIBUTING.md#ai-usage-policy). This project uses AI tools responsibly - all code is human-reviewed before merging, and all contributions must disclose AI usage.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -281,6 +281,39 @@ sequenceDiagram
 
 If a local port is already in use, the forward is marked as a conflict and reported in `graft status`.
 
+## Security model
+
+### Local and remote daemon sockets
+
+The local daemon listens on a Unix socket at `~/.local/state/graft/local/graftd.sock` (see `Server.Run` in `pkg/server.go`). A client that can `connect(2)` to that socket can run arbitrary commands on any configured remote, open new connections, and read session state. Two POSIX checks have to pass for a connection to succeed:
+
+1. **Directory traversal.** The state directory tree under `~/.local/state/graft/` is created by `os.MkdirAll(sockDir, DirPerms)` during server construction in `pkg/server.go`, using `DirPerms = 0o750` from `pkg/utils.go`. Users outside the owning group cannot walk into the tree to reach the socket at all.
+2. **Socket write permission.** The socket file is created by the `listenUnixSocket` helper in `pkg/utils.go`, which calls `net.Listen("unix", path)` and then chmods the result to `FilePerms = 0o600`. Both Linux and macOS enforce the write bit on `connect(2)` on a Unix socket, so only the socket's owning user can dial it.
+
+With those two checks in place, only the user who started the daemon can reach it. Graft does not sandbox or authenticate individual clients beyond that, however, so any process running under that user (a shell, a language SDK, a compromised package) has the same level of access the user does.
+
+The remote daemon (`graft daemon --as-remote`) reuses the same startup path, so the same permission story applies to its socket at `~/.local/state/graft/remote/graftd.sock` on the remote machine. The SSH agent forwarding bridge in `pkg/server_grpc_connection.go` creates a short-lived socket under `/tmp` and goes through the same `listenUnixSocket` helper, so the world-accessible `/tmp` parent directory does not weaken the restriction; the socket file itself is still owner-only.
+
+### Direction of RPCs
+
+Every gRPC method (`RunCommand`, `WatchPorts`, `ForwardPort`, `SyncFilesToConnectionProtocol`, and the rest, defined in `proto/graft/v1/graft.proto`) is initiated by the local daemon and serviced by the remote daemon. Local is always the client; remote is always the server. There is no reverse connection, and the remote machine has no endpoint to reach on the local machine outside the SSH session that the local daemon itself opened.
+
+This direction matters when reasoning about a compromised remote. If the remote account is taken over, the attacker cannot initiate arbitrary actions against the local daemon. What they can do is return malicious data in response to RPCs the local daemon has already made:
+
+- A `WatchPorts` server stream can report ports that are not actually listening, which causes the local daemon to open local listeners and relay accepted traffic to an attacker-chosen target on the remote.
+- `ForwardPort`, `RunCommand`, and other streaming responses carry payloads that reach the local daemon's parsing and handling code; a bug there is reachable from the remote.
+- `SyncFilesToConnectionProtocol` tunnels mutagen's sync protocol, so compromise of that stream is equivalent to compromise of the mutagen peer on the local side, with the same ability to write files within the configured sync roots.
+
+The blast radius is bounded by what the local daemon does with remote responses. A compromised remote cannot run arbitrary commands on the local machine.
+
+### File synchronization
+
+Files moved by `graft sync` are written by mutagen under the remote user's account and inherit that user's filesystem permissions. Graft does not attempt to preserve or translate ownership across machines, and it does not run as root on either end.
+
+### Authentication
+
+Graft does no authentication of its own. It relies on operating-system permissions at each end of a connection, and on SSH (or Docker) for the channel between them.
+
 ## Key directories
 
 | Path | Purpose |

--- a/pkg/server.go
+++ b/pkg/server.go
@@ -3,7 +3,6 @@ package graft
 import (
 	"context"
 	"log/slog"
-	"net"
 	"os"
 	"path/filepath"
 	"slices"
@@ -199,7 +198,7 @@ func (srv *Server) Run(runCtx context.Context) error {
 		})
 	}
 
-	listener, err := net.Listen("unix", srv.sockPath) //nolint:noctx
+	listener, err := listenUnixSocket(srv.sockPath)
 	if err != nil {
 		// TODO(erd): Listen failure may leave restore goroutine blocked indefinitely.
 		return errors.Wrap(err)

--- a/pkg/server_grpc_connection.go
+++ b/pkg/server_grpc_connection.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -694,7 +693,7 @@ func (srv *Server) ForwardSSHAgent(server graftv1.GraftService_ForwardSSHAgentSe
 
 	slog.DebugContext(server.Context(), "local ssh agent uds sock", "path", sockFile.Name())
 
-	listener, err := net.Listen("unix", sockFile.Name()) //nolint:noctx
+	listener, err := listenUnixSocket(sockFile.Name())
 	if err != nil {
 		// TODO(erd): Listen failure may leave restore goroutine blocked indefinitely.
 		return errors.Wrap(err)

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -37,6 +37,26 @@ const (
 	graftDirName = "graft"
 )
 
+// listenUnixSocket creates a unix domain socket listener at path and chmods
+// it to FilePerms (0o600). Linux and macOS both enforce the write bit on
+// connect(2), so this restricts the socket to its owning user even when the
+// parent directory allows traversal or the process umask is unusually
+// permissive.
+func listenUnixSocket(path string) (net.Listener, error) {
+	listener, err := net.Listen("unix", path) //nolint:noctx
+	if err != nil {
+		return nil, errors.Wrap(err)
+	}
+
+	if err := os.Chmod(path, FilePerms); err != nil {
+		_ = listener.Close()
+
+		return nil, errors.Wrap(err)
+	}
+
+	return listener, nil
+}
+
 // hasPathPrefix checks whether path has the given prefix on a directory boundary.
 // It returns the remaining suffix and true if the prefix matches.
 // For example, hasPathPrefix("/home/user/proj", "/home/user") returns ("/proj", true)

--- a/pkg/utils_test.go
+++ b/pkg/utils_test.go
@@ -1,9 +1,14 @@
 package graft
 
 import (
+	"context"
+	"net"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"go.viam.com/test"
 )
 
 // testEnv holds environment variable settings for a test case.
@@ -404,4 +409,55 @@ func TestSessionPath(t *testing.T) {
 	if path != want {
 		t.Errorf("got %q, want %q", path, want)
 	}
+}
+
+func TestListenUnixSocket(t *testing.T) {
+	// t.TempDir() produces paths too long for sockaddr_un on macOS, so use /tmp directly.
+	newSocketDir := func(t *testing.T) string {
+		t.Helper()
+
+		dir, err := os.MkdirTemp("/tmp", "lus-") //nolint:usetesting
+		test.That(t, err, test.ShouldBeNil)
+		t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+		return dir
+	}
+
+	t.Run("restricts the socket to mode 0600", func(t *testing.T) {
+		path := filepath.Join(newSocketDir(t), "test.sock")
+
+		listener, err := listenUnixSocket(path)
+		test.That(t, err, test.ShouldBeNil)
+		t.Cleanup(func() {
+			if listener != nil {
+				_ = listener.Close()
+			}
+		})
+
+		info, err := os.Stat(path)
+		test.That(t, err, test.ShouldBeNil)
+		test.That(t, info.Mode()&os.ModeSocket, test.ShouldNotEqual, os.FileMode(0))
+		test.That(t, info.Mode().Perm(), test.ShouldEqual, os.FileMode(0o600))
+	})
+
+	t.Run("accepts connections from the owning process", func(t *testing.T) {
+		path := filepath.Join(newSocketDir(t), "test.sock")
+
+		listener, err := listenUnixSocket(path)
+		test.That(t, err, test.ShouldBeNil)
+		t.Cleanup(func() { _ = listener.Close() })
+
+		var dialer net.Dialer
+
+		conn, err := dialer.DialContext(context.Background(), "unix", path)
+		test.That(t, err, test.ShouldBeNil)
+
+		_ = conn.Close()
+	})
+
+	t.Run("returns an error when the parent directory is missing", func(t *testing.T) {
+		listener, err := listenUnixSocket(filepath.Join(newSocketDir(t), "missing", "test.sock"))
+		test.That(t, err, test.ShouldNotBeNil)
+		test.That(t, listener, test.ShouldBeNil)
+	})
 }


### PR DESCRIPTION
## Summary
A user asked about graftd.sock and its security implications to which I realized I've never explained why it's safe. 
