### PR TITLE
build: make sure cgo_enabled is 1 for darwin and enforce builds come from there

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,9 +19,13 @@
         pname = "graft";
         inherit version;
         src = ./.;
-        vendorHash = "sha256-dxEgYsDC0R6yBiIswsnsHhGxyUlPCuAP8PTiBKZtnQE=";
+        vendorHash = "sha256-RWDQ0+caE+KVwasOFO1uF81Sfs7QC0fb6sEfa5acMFs=";
         goSum = ./go.sum;
-        env.CGO_ENABLED = "0";
+        # darwin needs cgo for mutagen's FSEvents watcher.
+        env.CGO_ENABLED =
+          if pkgs.stdenv.hostPlatform.isDarwin
+          then "1"
+          else "0";
 
         nativeBuildInputs = [pkgs.just pkgs.zstd];
 

--- a/justfile
+++ b/justfile
@@ -16,18 +16,18 @@ _LD_BUILD_VERSION := if BUILD_VERSION != "" { " -X github.com/edaniels/graft/pkg
 [private]
 _LD_BUILD_UPDATE_URL := if BUILD_UPDATE_URL != "" { " -X github.com/edaniels/graft/pkg.defaultUpdateURL=" + BUILD_UPDATE_URL } else { "" }
 LD_FLAGS := '-ldflags "-w -s' + _LD_BUILD_VERSION + _LD_BUILD_UPDATE_URL + '"'
-GO_ENV_FLAGS := "CGO_ENABLED=0 GOBIN=$HOME/go/bin"
+GO_ENV_FLAGS := "GOBIN=$HOME/go/bin"
 GO_BUILD_FLAGS := '-trimpath ' + if env('RACE', 'false') == "true" { "-race" } else { "" }
 PLATFORMS := "linux-amd64 linux-arm64 darwin-arm64"
 LINT_GOOS_LIST := "linux darwin"
 
 # Build a single platform binary (no embedding)
 build-graft os arch:
-    {{ GO_ENV_FLAGS }} GOOS={{ os }} GOARCH={{ arch }} go build {{ GO_BUILD_FLAGS }} {{ LD_FLAGS }} -o {{ BIN_DIR }}/{{ DAEMON_NAME }}-{{ os }}-{{ arch }} {{ GRAFT_PKG }}
+    CGO_ENABLED={{ if os == "darwin" { "1" } else { "0" } }} {{ GO_ENV_FLAGS }} GOOS={{ os }} GOARCH={{ arch }} go build {{ GO_BUILD_FLAGS }} {{ LD_FLAGS }} -o {{ BIN_DIR }}/{{ DAEMON_NAME }}-{{ os }}-{{ arch }} {{ GRAFT_PKG }}
 
 # Build a single platform binary with embedded binaries (requires prepare-embedded first)
 build-graft-embedded os arch:
-    {{ GO_ENV_FLAGS }} GOOS={{ os }} GOARCH={{ arch }} go build {{ GO_BUILD_FLAGS }} -tags embed_binaries {{ LD_FLAGS }} -o {{ BIN_DIR }}/{{ DAEMON_NAME }}-{{ os }}-{{ arch }} {{ GRAFT_PKG }}
+    CGO_ENABLED={{ if os == "darwin" { "1" } else { "0" } }} {{ GO_ENV_FLAGS }} GOOS={{ os }} GOARCH={{ arch }} go build {{ GO_BUILD_FLAGS }} -tags embed_binaries {{ LD_FLAGS }} -o {{ BIN_DIR }}/{{ DAEMON_NAME }}-{{ os }}-{{ arch }} {{ GRAFT_PKG }}
 
 # Build and install graft for current host with embedded binaries for remote deployment
 graft: prepare-embedded
@@ -39,8 +39,21 @@ graft: prepare-embedded
 graft-dev:
     {{ GO_ENV_FLAGS }} go install {{ GO_BUILD_FLAGS }} {{ GRAFT_PKG }}
 
-# Build all deployment target binaries and compress for embedding
-prepare-embedded: build-all
+# Build all deployment target binaries and compress for embedding. Darwin can
+# only be cross-compiled with cgo from a darwin host, so non-darwin hosts skip
+
+# the darwin daemon (the resulting graft binary can only push linux daemons).
+[linux]
+prepare-embedded:
+    just --justfile {{ justfile() }} build-graft linux amd64
+    just --justfile {{ justfile() }} build-graft linux arm64
+    just --justfile {{ justfile() }} compress-binaries
+
+[macos]
+prepare-embedded:
+    just --justfile {{ justfile() }} build-graft linux amd64
+    just --justfile {{ justfile() }} build-graft linux arm64
+    just --justfile {{ justfile() }} build-graft darwin arm64
     just --justfile {{ justfile() }} compress-binaries
 
 # Compress binaries for embedding (requires binaries to exist in bin/)
@@ -124,8 +137,16 @@ ci-lint:
         exit 1; \
     fi
 
+[linux]
 ci-build:
-    just build-all
+    just build-graft linux amd64
+    just build-graft linux arm64
+
+[macos]
+ci-build:
+    just build-graft linux amd64
+    just build-graft linux arm64
+    just build-graft darwin arm64
 
 update-deps:
     go get -u ./...

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -49,6 +49,12 @@ if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; the
     err "Invalid version format: $VERSION (expected semver like 0.1.0 or 0.1.0-beta.1)"
 fi
 
+# The darwin-arm64 release binary needs CGO=1 so mutagen's FSEvents watcher
+# compiles in (otherwise file syncs poll every 10s).
+if [ "$(uname -s)" != "Darwin" ]; then
+    err "Releases must be built on macOS"
+fi
+
 # Check for required tools
 command -v gh >/dev/null 2>&1 || err "gh CLI is required but not installed"
 command -v just >/dev/null 2>&1 || err "just is required but not installed"

--- a/thirdparty/mutagen/pkg/synchronization/endpoint/local/endpoint.go
+++ b/thirdparty/mutagen/pkg/synchronization/endpoint/local/endpoint.go
@@ -503,6 +503,19 @@ func NewEndpoint(
 		watchPollingInterval = version.DefaultWatchPollingInterval()
 	}
 
+	switch actualWatchMode {
+	case reifiedWatchModeRecursive:
+		endpoint.logger.Debugf("watcher: native recursive (re-establish poll %ds)", watchPollingInterval)
+	case reifiedWatchModePoll:
+		if nonRecursiveWatchingAllowed && watching.NonRecursiveWatchingSupported {
+			endpoint.logger.Debugf("watcher: poll (interval %ds, with native non-recursive accel)", watchPollingInterval)
+		} else {
+			endpoint.logger.Debugf("watcher: poll (interval %ds, no native watching)", watchPollingInterval)
+		}
+	case reifiedWatchModeDisabled:
+		endpoint.logger.Debug("watcher: disabled")
+	}
+
 	// Start the watching Goroutine.
 	go func() {
 		if actualWatchMode == reifiedWatchModePoll {


### PR DESCRIPTION
## Summary
I must have been using dev builds so frequently that I didn't realize CGO_ENABLED=0 on darwin was causing fs notify to not get used and instead we were on the 10 second poller. Added some debug logging for future me.
