### PR TITLE
better error message on lack of connection

### DIFF
--- a/pkg/session_manager.go
+++ b/pkg/session_manager.go
@@ -527,7 +527,8 @@ func (mgr *SessionManager) Which(
 // The selection hierarchy is:
 // 1. Explicit connection name
 // 2. Session-pinned connection (via `graft use`)
-// 3. CWD-based auto-selection.
+// 3. CWD-based auto-selection
+// 4. Sole-connection fallback (if exactly one connection exists).
 func (mgr *SessionManager) selectConnection(ctx context.Context, sess *Session, connName string, cwd string) (*Connection, error) {
 	logger := slog.Default().With("pid", sess.pid)
 
@@ -556,6 +557,13 @@ func (mgr *SessionManager) selectConnection(ctx context.Context, sess *Session, 
 		selectedConn, haveConn := mgr.connMgr.connectionByCWD(ctx, cwd)
 		if haveConn {
 			return selectedConn, nil
+		}
+	}
+
+	if conns := mgr.connMgr.Connections(); len(conns) == 1 {
+		for _, conn := range conns {
+			logger.Log(ctx, slogLevelNoisy, "using sole connection as fallback", "name", conn.Name())
+			return conn, nil
 		}
 	}
 

--- a/pkg/session_manager.go
+++ b/pkg/session_manager.go
@@ -559,7 +559,14 @@ func (mgr *SessionManager) selectConnection(ctx context.Context, sess *Session, 
 		}
 	}
 
-	return nil, errors.New("failed to find an eligible connection. To use without an explicit connection pin a session with 'graft use'")
+	for connName = range mgr.connMgr.Connections() {
+		break
+	}
+
+	return nil, errors.Errorf(
+		"failed to find an eligible connection; to use without an explicit connection pin with 'graft use %s'",
+		connName,
+	)
 }
 
 // resolveSessionConnection returns the connection for a session, applying the

--- a/pkg/session_manager.go
+++ b/pkg/session_manager.go
@@ -527,8 +527,7 @@ func (mgr *SessionManager) Which(
 // The selection hierarchy is:
 // 1. Explicit connection name
 // 2. Session-pinned connection (via `graft use`)
-// 3. CWD-based auto-selection
-// 4. Sole-connection fallback (if exactly one connection exists).
+// 3. CWD-based auto-selection.
 func (mgr *SessionManager) selectConnection(ctx context.Context, sess *Session, connName string, cwd string) (*Connection, error) {
 	logger := slog.Default().With("pid", sess.pid)
 

--- a/pkg/session_manager.go
+++ b/pkg/session_manager.go
@@ -563,6 +563,7 @@ func (mgr *SessionManager) selectConnection(ctx context.Context, sess *Session, 
 	if conns := mgr.connMgr.Connections(); len(conns) == 1 {
 		for _, conn := range conns {
 			logger.Log(ctx, slogLevelNoisy, "using sole connection as fallback", "name", conn.Name())
+
 			return conn, nil
 		}
 	}

--- a/pkg/session_manager.go
+++ b/pkg/session_manager.go
@@ -560,13 +560,13 @@ func (mgr *SessionManager) selectConnection(ctx context.Context, sess *Session, 
 	}
 
 	for connName = range mgr.connMgr.Connections() {
-		break
+		return nil, errors.Errorf(
+			"failed to find an eligible connection; to use without an explicit connection pin with 'graft use %s'",
+			connName,
+		)
 	}
 
-	return nil, errors.Errorf(
-		"failed to find an eligible connection; to use without an explicit connection pin with 'graft use %s'",
-		connName,
-	)
+	return nil, errors.New("failed to find an eligible connection")
 }
 
 // resolveSessionConnection returns the connection for a session, applying the

--- a/pkg/session_manager.go
+++ b/pkg/session_manager.go
@@ -560,15 +560,7 @@ func (mgr *SessionManager) selectConnection(ctx context.Context, sess *Session, 
 		}
 	}
 
-	if conns := mgr.connMgr.Connections(); len(conns) == 1 {
-		for _, conn := range conns {
-			logger.Log(ctx, slogLevelNoisy, "using sole connection as fallback", "name", conn.Name())
-
-			return conn, nil
-		}
-	}
-
-	return nil, errors.New("failed to find an eligible connection")
+	return nil, errors.New("failed to find an eligible connection. To use without an explicit connection pin a session with 'graft use'")
 }
 
 // resolveSessionConnection returns the connection for a session, applying the

--- a/pkg/session_manager_test.go
+++ b/pkg/session_manager_test.go
@@ -181,6 +181,33 @@ func TestSelectConnectionClearPin(t *testing.T) {
 	test.That(t, conn.Name(), test.ShouldEqual, "connA")
 }
 
+func TestSelectConnectionSingleConnectionFallback(t *testing.T) {
+	rootA := t.TempDir()
+
+	mgr, sessionsRoot := newTestSessionManager(t, map[string]*Connection{
+		"only-conn": newTestConnection("only-conn", rootA),
+	})
+
+	pid := uint64(99991)
+	sessPath := SessionPathFromRoot(sessionsRoot, "99991")
+
+	t.Cleanup(func() { os.RemoveAll(sessPath) })
+
+	ctx := context.Background()
+
+	// Set CWD to something outside any connection root.
+	err := mgr.UpdateSessionCWD(ctx, pid, t.TempDir())
+	test.That(t, err, test.ShouldBeNil)
+
+	sess, err := mgr.SessionByPID(pid)
+	test.That(t, err, test.ShouldBeNil)
+
+	// With only one connection, selectConnection should auto-select it since all other fallbacks fail
+	conn, err := mgr.selectConnection(ctx, sess, "", "/somewhere/else")
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, conn.Name(), test.ShouldEqual, "only-conn")
+}
+
 func TestPinConnectionValidatesExists(t *testing.T) {
 	mgr, sessionsRoot := newTestSessionManager(t, map[string]*Connection{})
 

--- a/pkg/session_manager_test.go
+++ b/pkg/session_manager_test.go
@@ -181,33 +181,6 @@ func TestSelectConnectionClearPin(t *testing.T) {
 	test.That(t, conn.Name(), test.ShouldEqual, "connA")
 }
 
-func TestSelectConnectionSingleConnectionFallback(t *testing.T) {
-	rootA := t.TempDir()
-
-	mgr, sessionsRoot := newTestSessionManager(t, map[string]*Connection{
-		"only-conn": newTestConnection("only-conn", rootA),
-	})
-
-	pid := uint64(99991)
-	sessPath := SessionPathFromRoot(sessionsRoot, "99991")
-
-	t.Cleanup(func() { os.RemoveAll(sessPath) })
-
-	ctx := context.Background()
-
-	// Set CWD to something outside any connection root.
-	err := mgr.UpdateSessionCWD(ctx, pid, t.TempDir())
-	test.That(t, err, test.ShouldBeNil)
-
-	sess, err := mgr.SessionByPID(pid)
-	test.That(t, err, test.ShouldBeNil)
-
-	// With only one connection, selectConnection should auto-select it since all other fallbacks fail
-	conn, err := mgr.selectConnection(ctx, sess, "", "/somewhere/else")
-	test.That(t, err, test.ShouldBeNil)
-	test.That(t, conn.Name(), test.ShouldEqual, "only-conn")
-}
-
 func TestPinConnectionValidatesExists(t *testing.T) {
 	mgr, sessionsRoot := newTestSessionManager(t, map[string]*Connection{})
 


### PR DESCRIPTION
## Summary
Add a 4th fallback to select connection, choosing the only connection if there is no ambiguity

## Test plan
Unit tests, tested on my machine with one connection to see if it works

## AI disclosure
AI unit test, which copies the existing tests

- [ ] I did **not** use AI tools to create this PR
- [x] I used AI tools (detail below)

**AI tools used:** Claude
**How AI was used:** code generation for unit tests
