### PR TITLE
lsp: better support remote files outside the sync root

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The plugin auto-triggers when you're working in a graft-managed directory, so yo
 | `use`        | Pin a connection to the current shell session                        |
 | `status`     | Show connection status                                               |
 | `doctor`     | Check environment setup and diagnose issues                          |
+| `lsp`        | Proxy a language server running on the remote ([details](#remote-language-servers-lsp)) |
 | `init`       | Generate a graft.yaml configuration file for future `graft connect`s |
 
 ## Connection selection
@@ -174,6 +175,64 @@ you (right in the `graft sync` output, and in the daemon log for config-driven
 syncs) when an include pattern is shadowed this way, so it never fails
 silently.
 
+## Remote language servers (LSP)
+
+Point your editor's LSP client at graft instead of the language server binary:
+
+```jsonc
+"command": ["graft", "lsp", "rust-analyzer"]
+```
+
+`graft lsp <server>` is a stdio LSP proxy. It starts `<server>` on the
+connection matching your working directory (falling back to a local `<server>`
+if the remote does not have one) and rewrites `file://` URIs between the local
+and remote sides using the connection's path remappings, so the server sees
+remote paths while your editor sees local ones.
+
+### Files that only exist on the remote (`graft://` URIs)
+
+Definitions often land in files outside the synced tree that only exist on the
+remote: the cargo registry, rust std sources, a Go module cache. The proxy
+rewrites those to `graft://<connection>/<remote-path>` URIs and serves their
+content read-only through the LSP 3.18 `workspace/textDocumentContent`
+request, so goto-definition opens the exact bytes the server analyzed, with no
+local copy of the toolchain required. Hover and further navigation keep
+working from inside those buffers; editing and saving them does not (they are
+read-only views).
+
+This requires an LSP client that supports `workspace/textDocumentContent`
+(proposed in LSP 3.18). Tested with Sublime Text's LSP package (>= 2.13.0).
+
+### Sublime Text setup
+
+In `Preferences > Package Settings > LSP > Settings`:
+
+```jsonc
+{
+  "clients": {
+    "rust-remote": {
+      "enabled": true,
+      "selector": "source.rust",
+      "command": ["graft", "lsp", "rust-analyzer"],
+      // Attach to graft:// buffers so goto-def and hover keep working from
+      // inside remote-only sources (the default is ["file"] only).
+      "schemes": ["file", "graft"],
+      // Syntax highlighting for those read-only buffers.
+      "syntax_map": {
+        "graft": "Packages/Rust/Rust.sublime-syntax"
+      }
+    }
+  }
+}
+```
+
+Editors title these buffers with the last segment of the URI, so graft marks
+the file name with the connection it came from, keeping the extension intact
+for editors that infer the language from it: goto-definition into the cargo
+registry opens a tab named `context@myconn.rs` rather than a bare
+`context.rs` that looks local. The marker is stripped before any path reaches
+the language server or the remote filesystem.
+
 ## Projects and workspaces
 
 Instead of passing flags to `graft connect` every time, you can save connection settings in a `graft.yaml` file.
@@ -232,7 +291,6 @@ graft use build          # explicitly switch to it
 ## Coming Soon
 
 - **Transparent SSH agent forwarding** -- use local SSH keys on the remote without manual setup (written, not yet tested)
-- **LSP support** -- run language servers remotely with local editor integration (written, not yet tested)
 
 ## Architecture
 

--- a/pkg/local_client_commands_lsp.go
+++ b/pkg/local_client_commands_lsp.go
@@ -1,6 +1,7 @@
 package graft
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -24,6 +25,21 @@ import (
 var (
 	clientRequestsWaiting atomic.Int32
 	serverRequestsWaiting atomic.Int32
+)
+
+// URI scheme, method, and capability names for serving remote-only file content.
+// Files outside every path remapping (e.g. cargo registry or toolchain sources)
+// that do not exist locally are exposed as graft://<connection>/<path> URIs whose
+// content is served over the connection via the LSP 3.18
+// workspace/textDocumentContent request instead of the local filesystem.
+const (
+	graftURIScheme                = "graft"
+	fileURIScheme                 = "file"
+	methodInitialize              = "initialize"
+	methodTextDocumentContent     = "workspace/textDocumentContent"
+	capTextDocumentContentFlat    = "textDocumentContentProvider"
+	capTextDocumentContentNested  = "textDocumentContent"
+	capTextDocumentContentSchemes = "schemes"
 )
 
 // ServeLSP serves a stdio LSP server forwarding responses from the session's connection.
@@ -59,7 +75,19 @@ func (client *LocalClient) ServeLSP(ctx context.Context, executable string) erro
 	var lspArgs lspRewriterArgs
 
 	lspArgs.Executable = executable
+	lspArgs.ConnectionName = selectResp.GetConnectionName()
+	lspArgs.ClientSupportsContent = new(atomic.Bool)
 	lspArgs.Remappings = selectResp.GetPathRemappings()
+
+	if !connectionNameIsURIHostSafe(lspArgs.ConnectionName) {
+		// Without a URI-host-safe name we cannot mint graft URIs that round
+		// trip; path remapping still works, remote-only files just pass through.
+		fmt.Fprintf(os.Stderr,
+			"connection name %q cannot be used in URIs; remote-only files will not be served\n",
+			lspArgs.ConnectionName)
+
+		lspArgs.ConnectionName = ""
+	}
 
 	capIn := io.Discard
 	capOut := io.Discard
@@ -212,6 +240,24 @@ func (l *lspBinder) Bind(ctx context.Context, conn *jsonrpc2.Connection) (jsonrp
 
 	headerFramer := jsonrpc2.HeaderFramer()
 
+	// A frame is written as multiple pipe writes and both the reader goroutine
+	// (responses to server requests) and the client handler (forwarded client
+	// requests) write to the server's stdin, so whole frames must be serialized.
+	var stdinMu sync.Mutex
+
+	stdinWriter := headerFramer.Writer(stdinPipe)
+
+	writeToServer := func(msg jsonrpc2.Message) error {
+		stdinMu.Lock()
+		defer stdinMu.Unlock()
+
+		if _, err := stdinWriter.Write(bindCtx, msg); err != nil {
+			return errors.Wrap(err)
+		}
+
+		return nil
+	}
+
 	// TODO(erd): trim over time
 	// TODO(erd): cant we just use a jsonrpc2.Connection instead as the abstraction to the command? probably
 	var inflightMu sync.Mutex
@@ -220,7 +266,6 @@ func (l *lspBinder) Bind(ctx context.Context, conn *jsonrpc2.Connection) (jsonrp
 
 	activeWorkers.Go(func() {
 		frameReader := headerFramer.Reader(stdoutPipe)
-		frameWriter := headerFramer.Writer(stdinPipe)
 
 		for {
 			msg, _, err := frameReader.Read(bindCtx)
@@ -234,12 +279,14 @@ func (l *lspBinder) Bind(ctx context.Context, conn *jsonrpc2.Connection) (jsonrp
 
 				var params any
 				if err := json.Unmarshal(v.Params, &params); err != nil {
-					_, _ = frameWriter.Write(bindCtx, &jsonrpc2.Response{ID: v.ID, Error: err}) //nolint:errcheck
+					serverRequestsWaiting.Add(-1)
+
+					errors.Unchecked(writeToServer(&jsonrpc2.Response{ID: v.ID, Error: err}))
 
 					continue
 				}
 
-				rewriteLocalRemoteURIs(params, l.args.Remappings, false)
+				rewriteLocalRemoteURIs(params, l.args, false)
 				// TODO(erd): do rewriting?
 
 				if !v.ID.IsValid() {
@@ -261,27 +308,23 @@ func (l *lspBinder) Bind(ctx context.Context, conn *jsonrpc2.Connection) (jsonrp
 				}
 
 				activeWorkers.Go(func() {
-					defer func() {
-					}()
 					defer serverRequestsWaiting.Add(-1)
 
 					var result any
 					if err := clientResp.Await(bindCtx, &result); err != nil {
-						_, _ = frameWriter.Write(bindCtx, &jsonrpc2.Response{ID: v.ID, Error: err}) //nolint:errcheck
+						errors.Unchecked(writeToServer(&jsonrpc2.Response{ID: v.ID, Error: err}))
 
 						return
 					}
 
-					rewriteLocalRemoteURIs(result, l.args.Remappings, true)
+					rewriteLocalRemoteURIs(result, l.args, true)
 
 					md, err := json.Marshal(result)
 					if err != nil {
 						return
 					}
 
-					if _, err := frameWriter.Write(bindCtx, &jsonrpc2.Response{ID: v.ID, Result: md}); err != nil {
-						return
-					}
+					errors.Unchecked(writeToServer(&jsonrpc2.Response{ID: v.ID, Result: md}))
 				})
 				inflightMu.Unlock()
 			case *jsonrpc2.Response:
@@ -303,7 +346,7 @@ func (l *lspBinder) Bind(ctx context.Context, conn *jsonrpc2.Connection) (jsonrp
 						continue
 					}
 
-					rewriteLocalRemoteURIs(results, l.args.Remappings, false)
+					rewriteLocalRemoteURIs(results, l.args, false)
 					// md, err := json.Marshal(results)
 					// if err != nil {
 					// 	continue
@@ -339,13 +382,56 @@ func (l *lspBinder) Bind(ctx context.Context, conn *jsonrpc2.Connection) (jsonrp
 
 			var params any
 			if err := json.Unmarshal(req.Params, &params); err != nil {
+				clientRequestsWaiting.Add(-1)
+
 				return nil, errors.Wrap(err)
 			}
 
-			rewriteLocalRemoteURIs(params, l.args.Remappings, true)
+			if req.Method == methodInitialize && l.args.ClientSupportsContent != nil &&
+				clientDeclaresTextDocumentContent(params) {
+				l.args.ClientSupportsContent.Store(true)
+			}
+
+			if isGraftDocumentEdit(req.Method, params) {
+				clientRequestsWaiting.Add(-1)
+
+				// Swallow edits to read-only graft documents; requests
+				// (willSaveWaitUntil) get a null result, notifications nothing.
+				//nolint:nilnil // deliberate null response
+				return nil, nil
+			}
+
+			if req.Method == methodTextDocumentContent && paramsURIScheme(params) == graftURIScheme {
+				// The language server does not know our scheme; serve the content
+				// ourselves from the remote side of the connection. Other schemes
+				// fall through to the server, which may natively support them.
+				if !req.ID.IsValid() {
+					clientRequestsWaiting.Add(-1)
+
+					//nolint:nilnil // a notification gets no response
+					return nil, nil
+				}
+
+				// Respond off the delivery goroutine so a slow transfer does not
+				// stall unrelated client traffic behind it.
+				go func() {
+					defer clientRequestsWaiting.Add(-1)
+
+					result, err := handleTextDocumentContent(params, l.args, func(path string) (string, error) {
+						return readRemoteFile(bindCtx, l.args.ConnectionName, path)
+					})
+					errors.Unchecked(conn.Respond(req.ID, result, err))
+				}()
+
+				return nil, jsonrpc2.ErrAsyncResponse
+			}
+
+			rewriteLocalRemoteURIs(params, l.args, true)
 
 			md, err := json.Marshal(params)
 			if err != nil {
+				clientRequestsWaiting.Add(-1)
+
 				return nil, errors.Wrap(err)
 			}
 
@@ -364,8 +450,15 @@ func (l *lspBinder) Bind(ctx context.Context, conn *jsonrpc2.Connection) (jsonrp
 				inflightMu.Unlock()
 			}
 
-			// TODO(erd): do we need to actually get the right responses to messages?
-			if _, err := headerFramer.Writer(stdinPipe).Write(bindCtx, req); err != nil {
+			if err := writeToServer(req); err != nil {
+				clientRequestsWaiting.Add(-1)
+
+				if respCh != nil {
+					inflightMu.Lock()
+					delete(inflightClientRequests, req.ID)
+					inflightMu.Unlock()
+				}
+
 				return nil, errors.Wrap(err)
 			}
 
@@ -376,18 +469,31 @@ func (l *lspBinder) Bind(ctx context.Context, conn *jsonrpc2.Connection) (jsonrp
 				return nil, nil
 			}
 
-			defer clientRequestsWaiting.Add(-1)
+			// Await the server's response off the delivery goroutine so one slow
+			// request does not serialize every other client request behind it.
+			go func() {
+				defer clientRequestsWaiting.Add(-1)
 
-			select {
-			case <-bindCtx.Done():
-				return nil, bindCtx.Err()
-			case resp := <-respCh:
-				if err, ok := resp.(error); ok {
-					return nil, errors.Wrap(err)
-				} else {
-					return resp, nil
+				select {
+				case <-bindCtx.Done():
+					errors.Unchecked(conn.Respond(req.ID, nil, bindCtx.Err()))
+				case resp := <-respCh:
+					if err, ok := resp.(error); ok {
+						errors.Unchecked(conn.Respond(req.ID, nil, errors.Wrap(err)))
+
+						return
+					}
+
+					if req.Method == methodInitialize && l.args.ConnectionName != "" &&
+						l.args.ClientSupportsContent != nil && l.args.ClientSupportsContent.Load() {
+						injectTextDocumentContentCapability(resp)
+					}
+
+					errors.Unchecked(conn.Respond(req.ID, resp, nil))
 				}
-			}
+			}()
+
+			return nil, jsonrpc2.ErrAsyncResponse
 		}),
 	}, nil
 }
@@ -404,11 +510,11 @@ func (v nilJSONValue) MarshalJSON() ([]byte, error) {
 }
 
 //nolint:gocognit // TODO(erd): too early to refactor
-func rewriteLocalRemoteURIs(value any, remappings []*graftv1.PathRemapping, forRemote bool) {
+func rewriteLocalRemoteURIs(value any, args lspRewriterArgs, forRemote bool) {
 	switch v := value.(type) {
 	case []any:
 		for _, elem := range v {
-			rewriteLocalRemoteURIs(elem, remappings, forRemote)
+			rewriteLocalRemoteURIs(elem, args, forRemote)
 		}
 	case map[string]any:
 		for mapK, mapV := range v {
@@ -419,7 +525,7 @@ func rewriteLocalRemoteURIs(value any, remappings []*graftv1.PathRemapping, forR
 					continue
 				}
 
-				for _, mapping := range remappings {
+				for _, mapping := range args.Remappings {
 					var from, to string
 					if forRemote {
 						from = mapping.GetFromPrefix()
@@ -430,7 +536,7 @@ func rewriteLocalRemoteURIs(value any, remappings []*graftv1.PathRemapping, forR
 					}
 
 					cutStr, found := strings.CutPrefix(vStr, from)
-					if !found {
+					if !found || !pathBoundaryOK(cutStr) {
 						continue
 					}
 
@@ -438,7 +544,7 @@ func rewriteLocalRemoteURIs(value any, remappings []*graftv1.PathRemapping, forR
 
 					break
 				}
-			case "uri", "rootUri", "scopeUri":
+			case "uri", "rootUri", "scopeUri", "targetUri", "target":
 				vStr, ok := mapV.(string)
 				if !ok {
 					continue
@@ -449,11 +555,28 @@ func rewriteLocalRemoteURIs(value any, remappings []*graftv1.PathRemapping, forR
 					continue
 				}
 
-				if parsedURL.Scheme != "file" {
+				if forRemote && parsedURL.Scheme == graftURIScheme {
+					// A URI we minted for a remote file outside every remapping;
+					// hand the real path back to the server.
+					if !strings.EqualFold(parsedURL.Host, args.ConnectionName) {
+						continue
+					}
+
+					parsedURL.Scheme = fileURIScheme
+					parsedURL.Host = ""
+					parsedURL.Path = stripRemotePathSegment(parsedURL.Path, args.ConnectionName)
+					v[mapK] = parsedURL.String()
+
 					continue
 				}
 
-				for _, mapping := range remappings {
+				if parsedURL.Scheme != fileURIScheme {
+					continue
+				}
+
+				var matched bool
+
+				for _, mapping := range args.Remappings {
 					var from, to string
 					if forRemote {
 						from = mapping.GetFromPrefix()
@@ -464,20 +587,234 @@ func rewriteLocalRemoteURIs(value any, remappings []*graftv1.PathRemapping, forR
 					}
 
 					cutStr, found := strings.CutPrefix(parsedURL.Path, from)
-					if !found {
+					if !found || !pathBoundaryOK(cutStr) {
 						continue
 					}
 
 					parsedURL.Path = filepath.Join(to, cutStr)
 					v[mapK] = parsedURL.String()
+					matched = true
 
 					break
 				}
+
+				if !matched && !forRemote && args.ConnectionName != "" &&
+					args.ClientSupportsContent != nil && args.ClientSupportsContent.Load() &&
+					!localPathExists(parsedURL.Path) {
+					// A remote-only file outside every synced tree (e.g. cargo
+					// registry or toolchain sources); point the client at our
+					// content provider. Paths that exist locally stay file URIs:
+					// they may be the client's own unmapped URIs echoed back
+					// (e.g. diagnostics for a file opened outside the sync root),
+					// which the client can read directly.
+					parsedURL.Scheme = graftURIScheme
+					parsedURL.Host = args.ConnectionName
+					parsedURL.Path = decorateRemotePathSegment(parsedURL.Path, args.ConnectionName)
+					v[mapK] = parsedURL.String()
+				}
 			default:
-				rewriteLocalRemoteURIs(mapV, remappings, forRemote)
+				rewriteLocalRemoteURIs(mapV, args, forRemote)
 			}
 		}
 	}
+}
+
+// injectTextDocumentContentCapability advertises that this proxy serves read-only
+// file content for the graft URI scheme, keeping any schemes the server natively
+// advertised. The nested form is the LSP 3.18 workspace/textDocumentContent
+// server capability; the flat form is the name Sublime Text's LSP package reads.
+func injectTextDocumentContentCapability(result any) {
+	resultMap, ok := result.(map[string]any)
+	if !ok {
+		return
+	}
+
+	caps, ok := resultMap["capabilities"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	workspace, ok := caps["workspace"].(map[string]any)
+	if !ok {
+		workspace = map[string]any{}
+		caps["workspace"] = workspace
+	}
+
+	schemes := []any{}
+
+	if existing, ok := workspace[capTextDocumentContentNested].(map[string]any); ok {
+		if existingSchemes, ok := existing[capTextDocumentContentSchemes].([]any); ok {
+			schemes = append(schemes, existingSchemes...)
+		}
+	}
+
+	if !slices.Contains(schemes, any(graftURIScheme)) {
+		schemes = append(schemes, graftURIScheme)
+	}
+
+	workspace[capTextDocumentContentNested] = map[string]any{capTextDocumentContentSchemes: schemes}
+	caps[capTextDocumentContentFlat] = map[string]any{capTextDocumentContentSchemes: schemes}
+}
+
+// clientDeclaresTextDocumentContent reports whether initialize request params
+// declare the LSP 3.18 workspace.textDocumentContent client capability, meaning
+// the client can fetch content for non-file URI schemes.
+func clientDeclaresTextDocumentContent(params any) bool {
+	paramsMap, ok := params.(map[string]any)
+	if !ok {
+		return false
+	}
+
+	caps, ok := paramsMap["capabilities"].(map[string]any)
+	if !ok {
+		return false
+	}
+
+	workspace, ok := caps["workspace"].(map[string]any)
+	if !ok {
+		return false
+	}
+
+	_, declared := workspace[capTextDocumentContentNested]
+
+	return declared
+}
+
+// paramsURIScheme extracts the scheme of a params.uri value, or empty if there
+// is none.
+func paramsURIScheme(params any) string {
+	paramsMap, ok := params.(map[string]any)
+	if !ok {
+		return ""
+	}
+
+	uriStr, ok := paramsMap["uri"].(string)
+	if !ok {
+		return ""
+	}
+
+	parsedURL, err := url.Parse(uriStr)
+	if err != nil {
+		return ""
+	}
+
+	return parsedURL.Scheme
+}
+
+// connectionNameIsURIHostSafe reports whether a connection name round trips
+// unchanged through the host component of a URI, which minted graft URIs
+// require.
+func connectionNameIsURIHostSafe(name string) bool {
+	if name == "" {
+		return false
+	}
+
+	minted := (&url.URL{Scheme: graftURIScheme, Host: name, Path: "/probe"}).String()
+
+	parsed, err := url.Parse(minted)
+	if err != nil {
+		return false
+	}
+
+	return strings.EqualFold(parsed.Host, name)
+}
+
+// pathBoundaryOK reports whether a prefix match ended on a path boundary,
+// preventing /a/bc from matching the prefix /a/b.
+func pathBoundaryOK(rest string) bool {
+	return rest == "" || strings.HasPrefix(rest, "/")
+}
+
+// decorateRemotePathSegment marks the file name of a minted graft URI with the
+// connection it came from, keeping the extension last so editors that infer a
+// language from it keep working: /a/context.rs becomes /a/context@conn.rs.
+// Editors title tabs for virtual documents with the last path segment, so the
+// marker is what distinguishes a served remote file from a local one.
+func decorateRemotePathSegment(path, connectionName string) string {
+	slash := strings.LastIndexByte(path, '/')
+	dir, name := path[:slash+1], path[slash+1:]
+
+	if name == "" {
+		return path
+	}
+
+	marker := "@" + connectionName
+
+	ext := filepath.Ext(name)
+
+	stem := strings.TrimSuffix(name, ext)
+	if stem == "" {
+		// Dotfiles and the like have no stem to mark; append instead.
+		return dir + name + marker
+	}
+
+	return dir + stem + marker + ext
+}
+
+// stripRemotePathSegment undoes decorateRemotePathSegment, recovering the real
+// remote path. Paths without the marker pass through unchanged.
+func stripRemotePathSegment(path, connectionName string) string {
+	slash := strings.LastIndexByte(path, '/')
+	dir, name := path[:slash+1], path[slash+1:]
+	marker := "@" + connectionName
+
+	ext := filepath.Ext(name)
+
+	stem := strings.TrimSuffix(name, ext)
+	if cut, ok := strings.CutSuffix(stem, marker); ok && cut != "" {
+		return dir + cut + ext
+	}
+
+	if cut, ok := strings.CutSuffix(name, marker); ok {
+		return dir + cut
+	}
+
+	return path
+}
+
+func localPathExists(path string) bool {
+	_, err := os.Stat(path)
+
+	return err == nil
+}
+
+// handleTextDocumentContent serves a workspace/textDocumentContent request for a
+// graft scheme URI by reading the file from the remote side of the connection.
+func handleTextDocumentContent(
+	params any,
+	args lspRewriterArgs,
+	readFile func(path string) (string, error),
+) (any, error) {
+	paramsMap, ok := params.(map[string]any)
+	if !ok {
+		return nil, errors.Errorf("expected map params for %s", methodTextDocumentContent)
+	}
+
+	uriStr, ok := paramsMap["uri"].(string)
+	if !ok {
+		return nil, errors.Errorf("expected string uri param for %s", methodTextDocumentContent)
+	}
+
+	parsedURL, err := url.Parse(uriStr)
+	if err != nil {
+		return nil, errors.Wrap(err)
+	}
+
+	if parsedURL.Scheme != graftURIScheme {
+		return nil, errors.Errorf("unsupported scheme %q for %s", parsedURL.Scheme, methodTextDocumentContent)
+	}
+
+	if !strings.EqualFold(parsedURL.Host, args.ConnectionName) {
+		return nil, errors.Errorf("URI is for connection %q but session is connected to %q",
+			parsedURL.Host, args.ConnectionName)
+	}
+
+	text, err := readFile(stripRemotePathSegment(parsedURL.Path, args.ConnectionName))
+	if err != nil {
+		return nil, errors.Wrap(err)
+	}
+
+	return map[string]any{"text": text}, nil
 }
 
 // ExecLocalLSP replaces the current process with the given executable, passing
@@ -492,6 +829,74 @@ func ExecLocalLSP(executable string) error {
 }
 
 type lspRewriterArgs struct {
-	Executable string
-	Remappings []*graftv1.PathRemapping
+	Executable     string
+	ConnectionName string
+	// ClientSupportsContent is set once the client's initialize request declares
+	// the workspace.textDocumentContent capability; graft URIs are only minted
+	// for clients that can fetch their content.
+	ClientSupportsContent *atomic.Bool
+	Remappings            []*graftv1.PathRemapping
+}
+
+// remoteReadCommand builds the graft run invocation (argv, then stdin payload)
+// used to read a remote file. The path travels NUL-terminated via stdin and is
+// consumed by `xargs -0`, which passes it to cat as a single literal argument.
+// It must not travel via argv: graft run wraps argv in a remote shell string,
+// and a further shell layer would expand path characters like $, * and ; (a
+// bare "$p" is expanded away by the wrapping shell before the inner shell runs).
+func remoteReadCommand(connectionName, path string) ([]string, string, error) {
+	if strings.ContainsRune(path, 0) {
+		// Impossible in a real filesystem path; guard the delimiter anyway.
+		return nil, "", errors.New("remote path contains a NUL byte")
+	}
+
+	return []string{
+		"run", "--to", connectionName,
+		"xargs", "-0", "cat", "--",
+	}, path + "\x00", nil
+}
+
+// readRemoteFile reads a file from the remote side of the named connection
+// through the same plumbing as graft run.
+func readRemoteFile(ctx context.Context, connectionName, path string) (string, error) {
+	args, stdin, err := remoteReadCommand(connectionName, path)
+	if err != nil {
+		return "", err
+	}
+
+	//nolint:gosec // the executable is ourselves and the argv is fixed; the path travels via stdin
+	execCmd := exec.CommandContext(ctx, os.Args[0], args...)
+
+	var stdout, stderr bytes.Buffer
+
+	execCmd.Stdin = strings.NewReader(stdin)
+	execCmd.Stdout = &stdout
+	execCmd.Stderr = &stderr
+
+	if err := execCmd.Run(); err != nil {
+		return "", errors.Errorf("failed to read remote file %q: %w: %s",
+			path, err, strings.TrimSpace(stderr.String()))
+	}
+
+	return stdout.String(), nil
+}
+
+// isGraftDocumentEdit reports whether a client message would modify a
+// read-only graft document (content served via workspace/textDocumentContent).
+// Conforming clients never edit such documents; dropping these protects the
+// real remote file from a misbehaving one.
+func isGraftDocumentEdit(method string, params any) bool {
+	switch method {
+	case "textDocument/didChange", "textDocument/didSave",
+		"textDocument/willSave", "textDocument/willSaveWaitUntil":
+	default:
+		return false
+	}
+
+	paramsMap, ok := params.(map[string]any)
+	if !ok {
+		return false
+	}
+
+	return paramsURIScheme(paramsMap["textDocument"]) == graftURIScheme
 }

--- a/pkg/local_client_commands_lsp_test.go
+++ b/pkg/local_client_commands_lsp_test.go
@@ -1,0 +1,468 @@
+package graft
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"go.viam.com/test"
+
+	"github.com/edaniels/graft/errors"
+	graftv1 "github.com/edaniels/graft/gen/proto/graft/v1"
+)
+
+var errReadFailed = errors.NewBare("read failed")
+
+func boolFlag(v bool) *atomic.Bool {
+	b := new(atomic.Bool)
+	b.Store(v)
+
+	return b
+}
+
+func lspTestArgs() lspRewriterArgs {
+	return lspRewriterArgs{
+		Executable:            "rust-analyzer",
+		ConnectionName:        "myconn",
+		ClientSupportsContent: boolFlag(true),
+		Remappings: []*graftv1.PathRemapping{
+			{FromPrefix: "/Users/eric/proj", ToPrefix: "/home/user/proj"},
+		},
+	}
+}
+
+func TestRewriteLocalRemoteURIsRewritesTargetURI(t *testing.T) {
+	args := lspTestArgs()
+	value := []any{
+		map[string]any{
+			"targetUri": "file:///home/user/proj/crates/foo/src/lib.rs",
+			"targetRange": map[string]any{
+				"start": map[string]any{"line": float64(1), "character": float64(0)},
+			},
+		},
+	}
+
+	rewriteLocalRemoteURIs(value, args, false)
+
+	link, ok := value[0].(map[string]any)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, link["targetUri"], test.ShouldEqual, "file:///Users/eric/proj/crates/foo/src/lib.rs")
+}
+
+func TestRewriteLocalRemoteURIsTargetURIToRemote(t *testing.T) {
+	args := lspTestArgs()
+	value := map[string]any{
+		"targetUri": "file:///Users/eric/proj/crates/foo/src/lib.rs",
+	}
+
+	rewriteLocalRemoteURIs(value, args, true)
+
+	test.That(t, value["targetUri"], test.ShouldEqual, "file:///home/user/proj/crates/foo/src/lib.rs")
+}
+
+func TestRewriteLocalRemoteURIsUnmappedBecomesGraftScheme(t *testing.T) {
+	args := lspTestArgs()
+	value := map[string]any{
+		"uri":       "file:///home/user/.cargo/registry/src/foo-1.0.0/src/lib.rs",
+		"targetUri": "file:///home/user/.rustup/toolchains/stable/lib/map.rs",
+	}
+
+	rewriteLocalRemoteURIs(value, args, false)
+
+	test.That(t, value["uri"], test.ShouldEqual,
+		"graft://myconn/home/user/.cargo/registry/src/foo-1.0.0/src/lib@myconn.rs")
+	test.That(t, value["targetUri"], test.ShouldEqual,
+		"graft://myconn/home/user/.rustup/toolchains/stable/lib/map@myconn.rs")
+}
+
+func TestRewriteLocalRemoteURIsMappedStillWinsOverGraftScheme(t *testing.T) {
+	args := lspTestArgs()
+	value := map[string]any{
+		"uri": "file:///home/user/proj/crates/foo/src/lib.rs",
+	}
+
+	rewriteLocalRemoteURIs(value, args, false)
+
+	test.That(t, value["uri"], test.ShouldEqual, "file:///Users/eric/proj/crates/foo/src/lib.rs")
+}
+
+func TestRewriteLocalRemoteURIsUnmappedLocalStaysPut(t *testing.T) {
+	// The local to remote direction must never invent graft URIs; the remote
+	// server can only ever read real files on its side.
+	args := lspTestArgs()
+	value := map[string]any{"uri": "file:///Users/eric/elsewhere/file.rs"}
+
+	rewriteLocalRemoteURIs(value, args, true)
+
+	test.That(t, value["uri"], test.ShouldEqual, "file:///Users/eric/elsewhere/file.rs")
+}
+
+func TestRewriteLocalRemoteURIsNoConnectionNameLeavesUnmapped(t *testing.T) {
+	args := lspTestArgs()
+	args.ConnectionName = ""
+	value := map[string]any{"uri": "file:///home/user/.cargo/x.rs"}
+
+	rewriteLocalRemoteURIs(value, args, false)
+
+	test.That(t, value["uri"], test.ShouldEqual, "file:///home/user/.cargo/x.rs")
+}
+
+func TestRewriteLocalRemoteURIsGraftSchemeBackToRemote(t *testing.T) {
+	args := lspTestArgs()
+	value := map[string]any{
+		"textDocument": map[string]any{
+			"uri": "graft://myconn/home/user/.cargo/registry/src/foo-1.0.0/src/lib@myconn.rs",
+		},
+	}
+
+	rewriteLocalRemoteURIs(value, args, true)
+
+	textDocument, ok := value["textDocument"].(map[string]any)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, textDocument["uri"], test.ShouldEqual,
+		"file:///home/user/.cargo/registry/src/foo-1.0.0/src/lib.rs")
+}
+
+func TestRemoteReadCommand(t *testing.T) {
+	nasty := "/home/x/weird $(id) [a]*?.rs"
+	args, stdin, err := remoteReadCommand("myconn", nasty)
+	test.That(t, err, test.ShouldBeNil)
+	// The path travels only via NUL-terminated stdin; argv is fixed, so no part
+	// of the path (and no shell metacharacter in it) reaches the remote shell.
+	test.That(t, stdin, test.ShouldEqual, nasty+"\x00")
+	test.That(t, args[0], test.ShouldEqual, "run")
+	test.That(t, args[1], test.ShouldEqual, "--to")
+	test.That(t, args[2], test.ShouldEqual, "myconn")
+
+	for _, arg := range args {
+		test.That(t, strings.Contains(arg, "weird"), test.ShouldBeFalse)
+		test.That(t, strings.ContainsRune(arg, '$'), test.ShouldBeFalse)
+	}
+
+	// Newlines in a path are fine (NUL is the delimiter); a NUL cannot appear.
+	_, _, err = remoteReadCommand("myconn", "/home/x/new\nline.rs")
+	test.That(t, err, test.ShouldBeNil)
+
+	_, _, err = remoteReadCommand("myconn", "/home/x/nul\x00.rs")
+	test.That(t, err, test.ShouldNotBeNil)
+}
+
+func TestRewriteLocalRemoteURIsDocumentLinkTarget(t *testing.T) {
+	args := lspTestArgs()
+	value := map[string]any{
+		"target": "file:///home/user/.cargo/registry/src/foo-1.0.0/README.md",
+		"range":  map[string]any{},
+	}
+
+	rewriteLocalRemoteURIs(value, args, false)
+	test.That(t, value["target"], test.ShouldEqual,
+		"graft://myconn/home/user/.cargo/registry/src/foo-1.0.0/README@myconn.md")
+
+	rewriteLocalRemoteURIs(value, args, true)
+	test.That(t, value["target"], test.ShouldEqual,
+		"file:///home/user/.cargo/registry/src/foo-1.0.0/README.md")
+}
+
+func TestIsGraftDocumentEdit(t *testing.T) {
+	graftDoc := map[string]any{
+		"textDocument": map[string]any{"uri": "graft://myconn/home/x@myconn.rs"},
+	}
+	fileDoc := map[string]any{
+		"textDocument": map[string]any{"uri": "file:///Users/eric/proj/x.rs"},
+	}
+
+	for _, method := range []string{
+		"textDocument/didChange", "textDocument/didSave",
+		"textDocument/willSave", "textDocument/willSaveWaitUntil",
+	} {
+		test.That(t, isGraftDocumentEdit(method, graftDoc), test.ShouldBeTrue)
+		test.That(t, isGraftDocumentEdit(method, fileDoc), test.ShouldBeFalse)
+	}
+
+	// Opening and closing read-only docs stays allowed.
+	test.That(t, isGraftDocumentEdit("textDocument/didOpen", graftDoc), test.ShouldBeFalse)
+	test.That(t, isGraftDocumentEdit("textDocument/didClose", graftDoc), test.ShouldBeFalse)
+	test.That(t, isGraftDocumentEdit("textDocument/didChange", nil), test.ShouldBeFalse)
+	test.That(t, isGraftDocumentEdit("textDocument/didChange", "bogus"), test.ShouldBeFalse)
+}
+
+func TestDecorateAndStripRemotePathSegment(t *testing.T) {
+	for path, decorated := range map[string]string{
+		"/a/b/context.rs":       "/a/b/context@myconn.rs",
+		"/a/b/Makefile":         "/a/b/Makefile@myconn",
+		"/a/b/.bashrc":          "/a/b/.bashrc@myconn",
+		"/a/b/file.tar.gz":      "/a/b/file.tar@myconn.gz",
+		"/a/b/x@myconn.rs":      "/a/b/x@myconn@myconn.rs",
+		"/spaced dir/f i le.rs": "/spaced dir/f i le@myconn.rs",
+	} {
+		test.That(t, decorateRemotePathSegment(path, "myconn"), test.ShouldEqual, decorated)
+		test.That(t, stripRemotePathSegment(decorated, "myconn"), test.ShouldEqual, path)
+	}
+
+	// An undecorated path passes through strip untouched.
+	test.That(t, stripRemotePathSegment("/a/b/context.rs", "myconn"),
+		test.ShouldEqual, "/a/b/context.rs")
+
+	// Degenerate paths pass through both untouched.
+	for _, path := range []string{"", "/", "/a/b/"} {
+		test.That(t, decorateRemotePathSegment(path, "myconn"), test.ShouldEqual, path)
+		test.That(t, stripRemotePathSegment(path, "myconn"), test.ShouldEqual, path)
+	}
+}
+
+func TestRewriteLocalRemoteURIsGraftSchemeOtherConnectionUntouched(t *testing.T) {
+	args := lspTestArgs()
+	value := map[string]any{"uri": "graft://other-conn/home/x.rs"}
+
+	rewriteLocalRemoteURIs(value, args, true)
+
+	test.That(t, value["uri"], test.ShouldEqual, "graft://other-conn/home/x.rs")
+}
+
+func TestRewriteLocalRemoteURIsLocallyExistingFileNotMinted(t *testing.T) {
+	// A URI whose path exists on the local machine is one the client can read
+	// directly; minting a graft URI for it would break clients whose own
+	// unmapped URIs get echoed back by the server (e.g. publishDiagnostics for
+	// a file opened outside the sync root).
+	args := lspTestArgs()
+	localFile := filepath.Join(t.TempDir(), "file.rs")
+	test.That(t, os.WriteFile(localFile, []byte("fn main() {}"), 0o600), test.ShouldBeNil)
+
+	value := map[string]any{"uri": "file://" + localFile}
+
+	rewriteLocalRemoteURIs(value, args, false)
+
+	test.That(t, value["uri"], test.ShouldEqual, "file://"+localFile)
+}
+
+func TestRewriteLocalRemoteURIsClientWithoutContentSupportNoMint(t *testing.T) {
+	// Clients that never declared workspace.textDocumentContent cannot open
+	// graft URIs at all; the raw remote path is no worse and sometimes works
+	// (identical layouts on both sides).
+	for _, flag := range []*atomic.Bool{nil, boolFlag(false)} {
+		args := lspTestArgs()
+		args.ClientSupportsContent = flag
+		value := map[string]any{"uri": "file:///home/user/.cargo/x.rs"}
+
+		rewriteLocalRemoteURIs(value, args, false)
+
+		test.That(t, value["uri"], test.ShouldEqual, "file:///home/user/.cargo/x.rs")
+	}
+}
+
+func TestRewriteLocalRemoteURIsMintPreservesQueryAndFragment(t *testing.T) {
+	args := lspTestArgs()
+	value := map[string]any{"uri": "file:///home/user/.cargo/x.rs?q=1#L10"}
+
+	rewriteLocalRemoteURIs(value, args, false)
+	test.That(t, value["uri"], test.ShouldEqual, "graft://myconn/home/user/.cargo/x@myconn.rs?q=1#L10")
+
+	rewriteLocalRemoteURIs(value, args, true)
+	test.That(t, value["uri"], test.ShouldEqual, "file:///home/user/.cargo/x.rs?q=1#L10")
+}
+
+func TestRewriteLocalRemoteURIsPrefixBoundary(t *testing.T) {
+	// /home/user/projfoo must not match the /home/user/proj
+	// remapping prefix; it is a remote-only file and should be minted instead
+	// of misrewritten to /Users/eric/projfoo.
+	args := lspTestArgs()
+	value := map[string]any{"uri": "file:///home/user/projfoo/src/x.rs"}
+
+	rewriteLocalRemoteURIs(value, args, false)
+
+	test.That(t, value["uri"], test.ShouldEqual, "graft://myconn/home/user/projfoo/src/x@myconn.rs")
+
+	// Same boundary rule on the way out.
+	value = map[string]any{"uri": "file:///Users/eric/projfoo/src/x.rs"}
+
+	rewriteLocalRemoteURIs(value, args, true)
+
+	test.That(t, value["uri"], test.ShouldEqual, "file:///Users/eric/projfoo/src/x.rs")
+}
+
+func TestConnectionNameIsURIHostSafe(t *testing.T) {
+	for name, want := range map[string]bool{
+		"myconn":  true,
+		"MyConn":  true, // case variant round trips (host matching is case-insensitive)
+		"conn_1":  true,
+		"my.host": true,
+		"a:1":     true, // parses as host:port but round trips intact
+		"my conn": false,
+		"a/b":     false,
+		"a:b":     false, // invalid port; does not survive url.Parse
+		"":        false,
+	} {
+		test.That(t, connectionNameIsURIHostSafe(name), test.ShouldEqual, want)
+	}
+}
+
+func TestClientDeclaresTextDocumentContent(t *testing.T) {
+	declared := map[string]any{
+		"capabilities": map[string]any{
+			"workspace": map[string]any{
+				"textDocumentContent": map[string]any{"dynamicRegistration": true},
+			},
+		},
+	}
+	test.That(t, clientDeclaresTextDocumentContent(declared), test.ShouldBeTrue)
+
+	for _, params := range []any{
+		nil,
+		"bogus",
+		map[string]any{},
+		map[string]any{"capabilities": map[string]any{}},
+		map[string]any{"capabilities": map[string]any{"workspace": map[string]any{}}},
+	} {
+		test.That(t, clientDeclaresTextDocumentContent(params), test.ShouldBeFalse)
+	}
+}
+
+func TestParamsURIScheme(t *testing.T) {
+	test.That(t, paramsURIScheme(map[string]any{"uri": "graft://myconn/x.rs"}), test.ShouldEqual, "graft")
+	test.That(t, paramsURIScheme(map[string]any{"uri": "future://x"}), test.ShouldEqual, "future")
+	test.That(t, paramsURIScheme(map[string]any{}), test.ShouldEqual, "")
+	test.That(t, paramsURIScheme(nil), test.ShouldEqual, "")
+}
+
+func TestInjectTextDocumentContentCapability(t *testing.T) {
+	result := map[string]any{
+		"capabilities": map[string]any{
+			"hoverProvider": true,
+			"workspace": map[string]any{
+				"workspaceFolders": map[string]any{"supported": true},
+			},
+		},
+	}
+
+	injectTextDocumentContentCapability(result)
+
+	caps, ok := result["capabilities"].(map[string]any)
+	test.That(t, ok, test.ShouldBeTrue)
+
+	// Flat name read by Sublime Text's LSP package (v2.13.0).
+	provider, ok := caps["textDocumentContentProvider"].(map[string]any)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, provider["schemes"], test.ShouldResemble, []any{"graft"})
+
+	// Spec (LSP 3.18) name, merged into the existing workspace capabilities.
+	workspace, ok := caps["workspace"].(map[string]any)
+	test.That(t, ok, test.ShouldBeTrue)
+	content, ok := workspace["textDocumentContent"].(map[string]any)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, content["schemes"], test.ShouldResemble, []any{"graft"})
+
+	test.That(t, workspace["workspaceFolders"], test.ShouldNotBeNil)
+	test.That(t, caps["hoverProvider"], test.ShouldEqual, true)
+}
+
+func TestInjectTextDocumentContentCapabilityMergesServerSchemes(t *testing.T) {
+	// A server with native textDocumentContent support keeps its own schemes.
+	result := map[string]any{
+		"capabilities": map[string]any{
+			"workspace": map[string]any{
+				"textDocumentContent": map[string]any{"schemes": []any{"rust-macro"}},
+			},
+		},
+	}
+
+	injectTextDocumentContentCapability(result)
+
+	caps, ok := result["capabilities"].(map[string]any)
+	test.That(t, ok, test.ShouldBeTrue)
+	workspace, ok := caps["workspace"].(map[string]any)
+	test.That(t, ok, test.ShouldBeTrue)
+	content, ok := workspace["textDocumentContent"].(map[string]any)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, content["schemes"], test.ShouldResemble, []any{"rust-macro", "graft"})
+
+	provider, ok := caps["textDocumentContentProvider"].(map[string]any)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, provider["schemes"], test.ShouldResemble, []any{"rust-macro", "graft"})
+}
+
+func TestInjectTextDocumentContentCapabilityNoWorkspace(t *testing.T) {
+	result := map[string]any{"capabilities": map[string]any{}}
+
+	injectTextDocumentContentCapability(result)
+
+	caps, ok := result["capabilities"].(map[string]any)
+	test.That(t, ok, test.ShouldBeTrue)
+	workspace, ok := caps["workspace"].(map[string]any)
+	test.That(t, ok, test.ShouldBeTrue)
+	content, ok := workspace["textDocumentContent"].(map[string]any)
+	test.That(t, ok, test.ShouldBeTrue)
+	test.That(t, content["schemes"], test.ShouldResemble, []any{"graft"})
+}
+
+func TestInjectTextDocumentContentCapabilityNonMapValues(t *testing.T) {
+	// Must not panic on shapes we do not expect and must leave them alone.
+	injectTextDocumentContentCapability(nil)
+	injectTextDocumentContentCapability("bogus")
+
+	result := map[string]any{"capabilities": "bogus"}
+	injectTextDocumentContentCapability(result)
+	test.That(t, result["capabilities"], test.ShouldEqual, "bogus")
+}
+
+func TestHandleTextDocumentContent(t *testing.T) {
+	args := lspTestArgs()
+
+	var gotPath string
+
+	readFile := func(path string) (string, error) {
+		gotPath = path
+
+		return "fn main() {}", nil
+	}
+
+	result, err := handleTextDocumentContent(map[string]any{
+		"uri": "graft://myconn/home/user/.cargo/registry/src/foo-1.0.0/src/lib@myconn.rs",
+	}, args, readFile)
+	test.That(t, err, test.ShouldBeNil)
+	test.That(t, gotPath, test.ShouldEqual, "/home/user/.cargo/registry/src/foo-1.0.0/src/lib.rs")
+	test.That(t, result, test.ShouldResemble, map[string]any{"text": "fn main() {}"})
+}
+
+func TestHandleTextDocumentContentRejectsNonGraftScheme(t *testing.T) {
+	args := lspTestArgs()
+	readFile := func(string) (string, error) { return "", nil }
+
+	_, err := handleTextDocumentContent(map[string]any{
+		"uri": "file:///home/user/.cargo/x.rs",
+	}, args, readFile)
+	test.That(t, err, test.ShouldNotBeNil)
+}
+
+func TestHandleTextDocumentContentRejectsOtherConnection(t *testing.T) {
+	args := lspTestArgs()
+	readFile := func(string) (string, error) { return "", nil }
+
+	_, err := handleTextDocumentContent(map[string]any{
+		"uri": "graft://other-conn/home/user/.cargo/x.rs",
+	}, args, readFile)
+	test.That(t, err, test.ShouldNotBeNil)
+}
+
+func TestHandleTextDocumentContentReadErrorPropagates(t *testing.T) {
+	args := lspTestArgs()
+	readFile := func(string) (string, error) { return "", errors.Wrap(errReadFailed) }
+
+	_, err := handleTextDocumentContent(map[string]any{
+		"uri": "graft://myconn/home/user/.cargo/x.rs",
+	}, args, readFile)
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, errReadFailed.Error())
+}
+
+func TestHandleTextDocumentContentBadParams(t *testing.T) {
+	args := lspTestArgs()
+	readFile := func(string) (string, error) { return "", nil }
+
+	_, err := handleTextDocumentContent("bogus", args, readFile)
+	test.That(t, err, test.ShouldNotBeNil)
+
+	_, err = handleTextDocumentContent(map[string]any{}, args, readFile)
+	test.That(t, err, test.ShouldNotBeNil)
+}

--- a/plugins/graft/skills/graft/references/commands.md
+++ b/plugins/graft/skills/graft/references/commands.md
@@ -78,8 +78,13 @@ communication).
 
 ### `graft lsp <remote-executable>`
 
-Run a remote language server with local-side I/O. Marked experimental in the
-proto definition; falls back to local execution if the daemon is unavailable.
+Run a remote language server with local-side I/O. Falls back to local
+execution if the daemon is unavailable or the remote lacks the executable.
+Rewrites file URIs using the connection's path remappings; files outside the
+synced tree (e.g. cargo registry sources) are exposed as read-only
+`graft://<connection>/<remote-path>` URIs served via the LSP 3.18
+`workspace/textDocumentContent` request. Editor setup is documented in the
+main README under "Remote language servers (LSP)".
 
 ## Forwarding
 


### PR DESCRIPTION
## Summary
there's a new graft scheme that lsps/ides can cooperatively use to open up remote files outside the sync root
